### PR TITLE
Add xvfb to services array; fixes broken CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: node_js
+dist: xenial
 node_js:
-- "node"
+- "10"
 services:
 - docker
+- xvfb
 before_install:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3
-  # Updating NPM to relevant version >= 3 on Node.JS LTS
-- npm i -g npm@^3
 - npm i -g brfs
 script:
 - npm run build


### PR DESCRIPTION
CI builds are currently failing for this repo. This PR fixes them by:

- Setting the `node_js` version to `10` explicitly (not doing so would allow Travis to install the latest version (v14+), which is incompatible with the version of [Angular](https://update.angular.io/?l=3&v=6.1-7.1) we use).

- Removing xvfb initialization logic from `before_install` script and instead adding `xvfb`  to the services array in the Travis config. This is necessitated by a breaking change introduced by Travis. More [here](https://benlimmer.com/2019/01/14/travis-ci-xvfb/) and [here](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services).