### PR TITLE
Fix lint errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,17 +3006,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
-      }
-    },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -3573,6 +3562,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "fill-range": {
           "version": "7.0.1",
@@ -4272,6 +4267,14 @@
       "dev": true,
       "requires": {
         "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
       }
     },
     "caller-path": {
@@ -5139,6 +5142,16 @@
         "parse-json": "^4.0.0"
       },
       "dependencies": {
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -9962,22 +9975,36 @@
           "dev": true,
           "optional": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "less": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
+      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.2",
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.83.0",
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "dev": true,
           "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -11779,6 +11806,11 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "find-up": {
           "version": "3.0.0",
@@ -15600,23 +15632,24 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15629,9 +15662,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -15639,20 +15672,11 @@
             "supports-color": "^5.3.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -15921,8 +15945,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "protractor": "~5.4.1",
     "replace-in-file": "^3.0.0",
     "ts-node": "~7.0.1",
-    "tslint": "~5.11.0",
+    "tslint": "^5.20.1",
     "typescript": "3.1.6",
     "webpack-version-file": "^0.1.3"
   },

--- a/src/app/Services/authentication/authentication.service.ts
+++ b/src/app/Services/authentication/authentication.service.ts
@@ -16,8 +16,8 @@ export class AuthenticationService {
     private sessionService: SessionService
   ) {
     if (
-      this.sessionStorageService.getItem(Constants.CREDENTIALS_KEY) != null &&
-      this.sessionStorageService.getItem(Constants.BASE_URL) != null
+      this.sessionStorageService.getItem(Constants.CREDENTIALS_KEY) !== null &&
+      this.sessionStorageService.getItem(Constants.BASE_URL) !== null
     ) {
       this.setCredentialsSubjectEncrypted(
         this.sessionStorageService.getItem(Constants.CREDENTIALS_KEY)

--- a/src/app/Services/constants.ts
+++ b/src/app/Services/constants.ts
@@ -11,7 +11,7 @@ export class Constants {
 
   public static readonly FORM_METADATA = 'formMetadata';
 
-  public static readonly TIME_STAMP = 'timestamp'; //for saving locally
+  public static readonly TIME_STAMP = 'timestamp'; //  for saving locally
 
   public static readonly COMPONENT = 'component';
 

--- a/src/app/Services/form-list.service.ts
+++ b/src/app/Services/form-list.service.ts
@@ -30,12 +30,12 @@ export class FormListService {
       }
     });
 
-    let sortedArray = [];
+    const sortedArray = [];
 
     // add items to the list of sorted array by using the metadata provided
     _.each(sortingMetadataArrays, (sortingMetadata) => {
       _.each(sortingMetadata, (metadata: any) => {
-        let found = this._findItemByName(metadata.name, unsortArray);
+        const found = this._findItemByName(metadata.name, unsortArray);
         if (found) {
           this._addMemberToArray(found, sortedArray);
         }
@@ -44,9 +44,9 @@ export class FormListService {
 
     // add missing items that weren't in the sorting metadata
     _.each(unsortArray, (item) => {
-      let found = this._findItemByName(item.name, sortedArray);
+      const found = this._findItemByName(item.name, sortedArray);
       if (_.isEmpty(found)) {
-        let toAdd = this._findItemByName(item.name, unsortArray);
+        const toAdd = this._findItemByName(item.name, unsortArray);
         this._addMemberToArray(toAdd, sortedArray);
       }
     });
@@ -59,7 +59,7 @@ export class FormListService {
       throw new Error('Input must be an array');
     }
 
-    let publishedOpenmrsForms = [];
+    const publishedOpenmrsForms = [];
 
     _.each(unsortArray, (item) => {
       if (item.published === true) {
@@ -98,13 +98,13 @@ export class FormListService {
     if (typeof formName !== 'string') {
       throw new Error('formName should be a string');
     }
-    let trimmed = formName.trim();
+    const trimmed = formName.trim();
     // minimum form length is 5 characters
     if (trimmed.length < 5) {
       return trimmed;
     }
-    let lastFiveCharacters = trimmed.substr(trimmed.length - 5);
-    let indexOfV =
+    const lastFiveCharacters = trimmed.substr(trimmed.length - 5);
+    const indexOfV =
       lastFiveCharacters.search('v') === -1
         ? lastFiveCharacters.search('V')
         : lastFiveCharacters.search('v');
@@ -126,9 +126,9 @@ export class FormListService {
 
   private _getFormList(pocForms, formOrderArray) {
     // first filter out unpublished forms
-    let effectiveForms = this.removeVersionInformationFromForms(pocForms);
-    let publishedForms = this.filterPublishedOpenmrsForms(effectiveForms);
-    let sortedList = this.sortFormList(publishedForms, formOrderArray);
+    const effectiveForms = this.removeVersionInformationFromForms(pocForms);
+    const publishedForms = this.filterPublishedOpenmrsForms(effectiveForms);
+    const sortedList = this.sortFormList(publishedForms, formOrderArray);
     return sortedList;
   }
   private _isVersionInformation(subString) {
@@ -149,7 +149,7 @@ export class FormListService {
   }
 
   private _findItemByName(name, array) {
-    let foundItems = [];
+    const foundItems = [];
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < array.length; i++) {
       // TODO: find a way to compare strings by first eliminating the spaces
@@ -165,7 +165,7 @@ export class FormListService {
   }
 
   private _findItemByUuid(uuid, array) {
-    let foundItems = [];
+    const foundItems = [];
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < array.length; i++) {
       // TODO: find a way to compare strings by first eliminating the spaces

--- a/src/app/Services/navigator.service.ts
+++ b/src/app/Services/navigator.service.ts
@@ -5,8 +5,8 @@ import { Constants } from './constants';
 
 @Injectable()
 export class NavigatorService {
-  schema: Object; //stores the state of the current schema and all the changes in memory.
-  rawSchema: Object; //stores the raw version of above
+  schema: Object; // stores the state of the current schema and all the changes in memory.
+  rawSchema: Object; // stores the raw version of above
   schemaEditorSubject: Subject<Object> = new Subject();
   rawSchemaEditorSubject: Subject<Object> = new Subject();
   schemaSubject: Subject<Object> = new Subject();
@@ -50,10 +50,10 @@ export class NavigatorService {
     parentQuestionIndex?: number,
     schema?: any
   ) {
-    if (questionIndex != undefined) {
+    if (questionIndex !== undefined) {
       console.log('ObsGroup Question!');
     }
-    let question = {};
+    const question = {};
     question['propModelArray'] = propModelArray;
     question['pageIndex'] = pageIndex;
     question['sectionIndex'] = sectionIndex;
@@ -78,7 +78,7 @@ export class NavigatorService {
 
   //  addToRawSchema(options:{},pageIndex?:number){
   //   let obj = this.rawSchemaSubject.getValue();
-  //    if(pageIndex==undefined){
+  //    if (pageIndex === undefined) {
   //     obj['pages'].push(options);
   //     this.setRawSchema(obj);
   //    }

--- a/src/app/Services/openmrs-api/fetch-all-forms.service.ts
+++ b/src/app/Services/openmrs-api/fetch-all-forms.service.ts
@@ -112,8 +112,8 @@ export class FetchAllFormsService {
   //     count = index;
   //     schemas.push({schema:schema,metadata:formMetadata});
   //     console.log(count,numberOfPOCForms,schemas.length);
-  //     if(count == numberOfPOCForms-1) {
-  //       //this.fetchAllFormsService.setAllPOCFormSchemas(schemas);
+  //     if(count === numberOfPOCForms-1) {
+  //       // this.fetchAllFormsService.setAllPOCFormSchemas(schemas);
   //       this.ls.setObject("POC_FORM_SCHEMAS",schemas);
   //       let finishTime = (new Date().getTime() - date)/1000;
   //       console.log("Done fetching schemas. Took " + finishTime + "seconds");

--- a/src/app/Services/question-control.service.ts
+++ b/src/app/Services/question-control.service.ts
@@ -19,8 +19,7 @@ export class QuestionControlService {
   ) {}
 
   toFormGroup(questions: PropertyModel<any>[]): FormGroup {
-    let group: any = {};
-    let ArrPropModelArray: any;
+    const group: any = {};
     questions.forEach((question) => {
       group[question.key] = question.required
         ? new FormControl(question.value || '', Validators.required)
@@ -32,10 +31,13 @@ export class QuestionControlService {
 
   toPropertyModelArray(schema: any) {
     this.propertyModels = [];
-    let flattenedSchema: any = this.flatten(schema);
+    const flattenedSchema: any = this.flatten(schema);
     console.log(flattenedSchema);
-    for (var prop in flattenedSchema) {
-      this.createFields(prop, flattenedSchema[prop]);
+    // TODO: Replace with for...of
+    for (const prop in flattenedSchema) {
+      if (flattenedSchema.hasOwnProperty(prop)) {
+        this.createFields(prop, flattenedSchema[prop]);
+      }
     }
 
     return this.propertyModels;
@@ -284,7 +286,9 @@ export class QuestionControlService {
       case 'validators':
         options.label = 'Validators';
         options.rows = 5;
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
@@ -302,7 +306,9 @@ export class QuestionControlService {
       case 'questionOptions.answers':
         options.label = 'Answers';
         options.rows = 5;
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
@@ -311,7 +317,9 @@ export class QuestionControlService {
       case 'historicalExpression':
         options.label = 'Historical Expression';
         options.rows = 4;
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
@@ -355,7 +363,9 @@ export class QuestionControlService {
       case 'questionOptions.showDateOptions':
         options.label = 'Show Date Options';
         options.rows = 5;
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
@@ -365,7 +375,9 @@ export class QuestionControlService {
         options.label = 'Show Weeks List';
         options.rows = 3;
         options.placeholder = '[2,12,16,18...]';
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
@@ -374,14 +386,16 @@ export class QuestionControlService {
       case 'alert':
         options.label = 'Alert';
         options.rows = 5;
-        if (value) options.value = JSON.stringify(value, undefined, '\t');
+        if (value) {
+          options.value = JSON.stringify(value, undefined, '\t');
+        }
         this.propertyModels.push(
           this.propertyFactory.createProperty('textarea', options)
         );
         break;
 
       case 'questionOptions.selectableOrders':
-        let p = this.properties.getPropertyByName('selectableOrders');
+        const p = this.properties.getPropertyByName('selectableOrders');
         p.value = JSON.stringify(value, undefined, '\t');
         this.propertyModels.push(p);
         break;
@@ -402,7 +416,7 @@ export class QuestionControlService {
   }
 
   flatten(data) {
-    var result = {};
+    const result = {};
 
     function recurse(cur, prop) {
       if (Object(cur) !== cur) {
@@ -410,12 +424,16 @@ export class QuestionControlService {
       } else if (Array.isArray(cur)) {
         result[prop] = cur;
       } else {
-        var isEmpty = true;
-        for (var p in cur) {
-          isEmpty = false;
-          recurse(cur[p], prop ? prop + '.' + p : p);
+        let isEmpty = true;
+        for (const p in cur) {
+          if (cur.hasOwnProperty(p)) {
+            isEmpty = false;
+            recurse(cur[p], prop ? prop + '.' + p : p);
+          }
         }
-        if (isEmpty && prop) result[prop] = {};
+        if (isEmpty && prop) {
+          result[prop] = {};
+        }
       }
     }
     recurse(data, '');
@@ -424,18 +442,22 @@ export class QuestionControlService {
 
   unflatten(data) {
     'use strict';
-    if (Object(data) !== data || Array.isArray(data)) return data;
-    var regex = /\.?([^.\[\]]+)|\[(\d+)\]/g,
+    if (Object(data) !== data || Array.isArray(data)) {
+      return data;
+    }
+    const regex = /\.?([^.\[\]]+)|\[(\d+)\]/g,
       resultholder = {};
-    for (var p in data) {
-      var cur = resultholder,
-        prop = '',
-        m;
-      while ((m = regex.exec(p))) {
-        cur = cur[prop] || (cur[prop] = m[2] ? [] : {});
-        prop = m[2] || m[1];
+    for (const p in data) {
+      if (data.hasOwnProperty(p)) {
+        let cur = resultholder,
+          prop = '',
+          m;
+        while ((m = regex.exec(p))) {
+          cur = cur[prop] || (cur[prop] = m[2] ? [] : {});
+          prop = m[2] || m[1];
+        }
+        cur[prop] = data[p];
       }
-      cur[prop] = data[p];
     }
     return resultholder[''] || resultholder;
   }

--- a/src/app/Services/question-id.service.ts
+++ b/src/app/Services/question-id.service.ts
@@ -13,14 +13,14 @@ export class QuestionIdService {
 
   private collectIDs(schema) {
     //   let $schema = _.cloneDeep(schema);
-    //     if($schema.pages!=null) this.collectIDs(schema.pages);
+    //     if($schema.pages!==ull) this.collectIDs(schema.pages);
     //     if(Array.isArray($schema)){
     //         $schema.forEach(element => {
     //             if(element.sections) this.collectIDs(element.sections)
     //             if(element.questions) this.collectIDs(element.questions)
     //             else {
     //                 let id = _.cloneDeep(element.id)
-    //             if(typeof(id) != 'undefined'){
+    //             if(typeof(id) !=='undefined'){
     //                this.IDs.push(id)
     //             }
     //         }

--- a/src/app/Services/route-guards/auth-guard.service.ts
+++ b/src/app/Services/route-guards/auth-guard.service.ts
@@ -18,7 +18,7 @@ export class AuthGuardService implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): boolean {
-    let url: string = state.url;
+    const url = state.url;
     return this.checkLogin(url);
   }
 

--- a/src/app/Services/schema-compiler.service.ts
+++ b/src/app/Services/schema-compiler.service.ts
@@ -19,7 +19,7 @@ export class FormSchemaCompiler {
     referencedComponents: Array<any>
   ): Object {
     // get all referenced forms
-    let refForms: Object = this.getReferencedForms(
+    const refForms: Object = this.getReferencedForms(
       formSchema,
       referencedComponents
     );
@@ -28,7 +28,7 @@ export class FormSchemaCompiler {
     }
 
     // get all place-holders from the form schema
-    let placeHolders = this.getAllPlaceholderObjects(formSchema);
+    const placeHolders = this.getAllPlaceholderObjects(formSchema);
     if (_.isEmpty(placeHolders)) {
       return formSchema;
     }
@@ -75,7 +75,7 @@ export class FormSchemaCompiler {
     if (_.isEmpty(schema) || _.isEmpty(pageLabel) || _.isEmpty(sectionLabel)) {
       return;
     }
-    let foundPage: any = this.getPageInSchemaByLabel(schema, pageLabel);
+    const foundPage: any = this.getPageInSchemaByLabel(schema, pageLabel);
     if (_.isEmpty(foundPage)) {
       return;
     }
@@ -107,7 +107,7 @@ export class FormSchemaCompiler {
       if (this.isQuestionObjectWithId(schema, questionId)) {
         return schema;
       } else if (this.isSchemaSubObjectExpandable(schema)) {
-        let toExpand = schema.pages || schema.sections || schema.questions;
+        const toExpand = schema.pages || schema.sections || schema.questions;
         return this.getQuestionByIdInSchema(toExpand, questionId);
       } else {
         return;
@@ -152,7 +152,7 @@ export class FormSchemaCompiler {
       if (this.isQuestionObjectWithId(object, questionId)) {
         return parent;
       } else if (this.isSchemaSubObjectExpandable(object)) {
-        let toExpand = object.pages || object.sections || object.questions;
+        const toExpand = object.pages || object.sections || object.questions;
         return this.getQuestionsArrayByQuestionId(
           toExpand,
           toExpand,
@@ -169,7 +169,7 @@ export class FormSchemaCompiler {
   // object is page or section or question
   private isSchemaSubObjectExpandable(object: Object): Boolean {
     if (typeof object === 'object') {
-      let objectKeys = Object.keys(object);
+      const objectKeys = Object.keys(object);
       if (
         _.includes(objectKeys, 'pages') ||
         _.includes(objectKeys, 'sections') ||
@@ -186,7 +186,7 @@ export class FormSchemaCompiler {
   }
 
   private getAllPlaceholderObjects(schema: Object): Array<any> {
-    let referencedObjects: Array<any> = [];
+    const referencedObjects: Array<any> = [];
     this.extractPlaceholderObjects(schema, referencedObjects);
     return referencedObjects;
   }
@@ -208,7 +208,7 @@ export class FormSchemaCompiler {
       if (!_.isEmpty(subSchema.reference)) {
         objectsArray.push(subSchema);
       } else if (this.isSchemaSubObjectExpandable(subSchema)) {
-        let toExpand =
+        const toExpand =
           subSchema.pages || subSchema.sections || subSchema.questions;
         this.extractPlaceholderObjects(toExpand, objectsArray);
       }
@@ -219,7 +219,7 @@ export class FormSchemaCompiler {
     placeHolderObject: Object,
     referenceObject: Object
   ): Object {
-    for (let member in referenceObject) {
+    for (const member in referenceObject) {
       if (_.isEmpty(placeHolderObject[member])) {
         placeHolderObject[member] = referenceObject[member];
       }
@@ -232,7 +232,7 @@ export class FormSchemaCompiler {
     placeHoldersArray: Array<any>
   ): Array<any> {
     _.each(placeHoldersArray, (placeHolder) => {
-      let referencedObject: Object = this.getReferencedObject(
+      const referencedObject: Object = this.getReferencedObject(
         placeHolder.reference,
         keyValReferencedForms
       );
@@ -252,7 +252,7 @@ export class FormSchemaCompiler {
   }
 
   private removeObjectFromArray(array: Array<any>, object: Object): void {
-    let indexOfObject = array.indexOf(object);
+    const indexOfObject = array.indexOf(object);
     if (indexOfObject === -1) {
       return;
     }
@@ -263,7 +263,7 @@ export class FormSchemaCompiler {
   private removeExcludedQuestionsFromPlaceholder(placeHolder: any): Object {
     if (Array.isArray(placeHolder.reference.excludeQuestions)) {
       _.each(placeHolder.reference.excludeQuestions, (excludedQuestionId) => {
-        let questionsArray: Array<any> = this.getQuestionsArrayByQuestionIdInSchema(
+        const questionsArray: Array<any> = this.getQuestionsArrayByQuestionIdInSchema(
           placeHolder,
           excludedQuestionId
         );
@@ -271,7 +271,7 @@ export class FormSchemaCompiler {
         if (!Array.isArray(questionsArray)) {
           return;
         }
-        let question = this.getQuestionByIdInSchema(
+        const question = this.getQuestionByIdInSchema(
           questionsArray,
           excludedQuestionId
         );
@@ -326,13 +326,13 @@ export class FormSchemaCompiler {
     formSchema: any,
     formSchemasLookupArray: Array<any>
   ): Object {
-    let referencedForms: Array<any> = formSchema.referencedForms;
+    const referencedForms: Array<any> = formSchema.referencedForms;
     console.log(referencedForms, formSchema, formSchemasLookupArray);
     if (_.isEmpty(referencedForms)) {
       return;
     }
 
-    let keyValReferencedForms: Object = {};
+    const keyValReferencedForms: Object = {};
 
     _.each(referencedForms, (reference: any) => {
       keyValReferencedForms[reference.alias] = this.findSchemaByName(

--- a/src/app/Services/storage/local-storage.service.ts
+++ b/src/app/Services/storage/local-storage.service.ts
@@ -11,9 +11,9 @@ export class LocalStorageService {
   }
 
   public getObject(keyName: string): any {
-    let stored = window.localStorage.getItem(keyName);
+    const stored = window.localStorage.getItem(keyName);
     try {
-      let object = JSON.parse(stored);
+      const object = JSON.parse(stored);
       return object;
     } catch (error) {
       console.error(error);

--- a/src/app/Services/storage/session-storage.service.ts
+++ b/src/app/Services/storage/session-storage.service.ts
@@ -11,9 +11,9 @@ export class SessionStorageService {
   }
 
   public getObject(keyName: string): any {
-    let stored = window.sessionStorage.getItem(keyName);
+    const stored = window.sessionStorage.getItem(keyName);
     try {
-      let object = JSON.parse(stored);
+      const object = JSON.parse(stored);
       return object;
     } catch (error) {
       console.error(error);

--- a/src/app/collections/linked-list.ts
+++ b/src/app/collections/linked-list.ts
@@ -10,12 +10,12 @@ export class Node {
 }
 
 export class LinkedList {
-  head: Node = null; //points to the first added list.
+  head: Node = null; // points to the first added list.
 
   append(formMetadata: any) {
-    let list = new Node(formMetadata);
-    if (this.head == null) {
-      this.head = list; //this is the first list;
+    const list = new Node(formMetadata);
+    if (this.head === null) {
+      this.head = list; // this is the first list;
     } else {
       let temp = this.head;
       while (temp.next) {
@@ -23,7 +23,7 @@ export class LinkedList {
       }
       list.previous = temp;
       list.next = null;
-      temp.next = list; //append new list to the end of the linked list.
+      temp.next = list; // append new list to the end of the linked list.
     }
   }
 }

--- a/src/app/form-editor/audit-info/audit-info.component.ts
+++ b/src/app/form-editor/audit-info/audit-info.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'audit-info',
   templateUrl: './audit-info.component.html',
   styleUrls: ['./audit-info.component.css']

--- a/src/app/form-editor/concept/concept.component.ts
+++ b/src/app/form-editor/concept/concept.component.ts
@@ -233,10 +233,10 @@ export class ConceptComponent implements OnInit, OnDestroy {
   }
 
   setSelectedAnswers(strUuids) {
-    let selectedAnswers = [];
+    const selectedAnswers = [];
     const uuids = JSON.parse(strUuids);
     _.forEach(uuids, (uuid) => {
-      let ans = this.getAns(uuid);
+      const ans = this.getAns(uuid);
       if (ans) {
         selectedAnswers.push(ans);
       }
@@ -257,9 +257,9 @@ export class ConceptComponent implements OnInit, OnDestroy {
   }
 
   createSchemaAnswers(answers: any[]) {
-    let schemaAns = [];
+    const schemaAns = [];
     _.forEach(answers, (answer) => {
-      let answerObj = {
+      const answerObj = {
         concept: answer.uuid,
         label: answer.display,
         conceptMappings: this.cs.createMappingsValue(answer.mappings)

--- a/src/app/form-editor/element-editor/dynamic-question/dynamic-question.component.html
+++ b/src/app/form-editor/element-editor/dynamic-question/dynamic-question.component.html
@@ -3,33 +3,19 @@
 
   <label [attr.for]="question.key" class="label">{{ question.label }}</label>
   <span>
-    <small *ngIf="!isControlValid(question.key)" class="text-danger"
-      >This field is required.</small
-    >
+    <small *ngIf="!isControlValid(question.key)" class="text-danger">This field is required.</small>
   </span>
 
   <div [ngSwitch]="question.controlType">
     <div [id]="question.label" class="">
       <div class="form-group">
-        <input
-          *ngSwitchCase="'textbox'"
-          class="form-control"
-          [formControlName]="question.key"
-          [id]="question.key"
-          [type]="question.type"
-          [placeholder]="question.placeholder"
-          [value]="question.value"
-          [type]="question.type"
-        />
+        <input *ngSwitchCase="'textbox'" class="form-control" [formControlName]="question.key" [id]="question.key"
+          [type]="question.type" [placeholder]="question.placeholder" [value]="question.value" [type]="question.type" />
       </div>
 
       <div class="form-group">
-        <select
-          *ngSwitchCase="'select'"
-          class="form-control"
-          [formControlName]="question.key"
-          (change)="typeSelected(question.key)"
-        >
+        <select *ngSwitchCase="'select'" class="form-control" [formControlName]="question.key"
+          (change)="typeSelected(question.key)">
           <option *ngFor="let opt of question.options" [value]="opt.key">
             {{ opt.value }}
           </option>
@@ -37,35 +23,18 @@
       </div>
 
       <div class="form-group ace-input">
-        <textarea
-          *ngSwitchCase="'textarea'"
-          [formControlName]="question.key"
-          style="display: none"
-          [value]="question.value"
-        ></textarea>
-        <div
-          *ngSwitchCase="'textarea'"
-          ace-editor
-          [(text)]="question.value"
-          [mode]="'javascript'"
-          [theme]="'chrome'"
-          [readOnly]="false"
-          [autoUpdateContent]="true"
-          [durationBeforeCallback]="1000"
-          (textChanged)="onTextAreaChanged($event, question.key)"
-          style="min-height: 200px; width: 100%"
-        ></div>
+        <textarea *ngSwitchCase="'textarea'" [formControlName]="question.key" style="display: none"
+          [value]="question.value"></textarea>
+        <div *ngSwitchCase="'textarea'" ace-editor [(text)]="question.value" [mode]="'javascript'" [theme]="'chrome'"
+          [readOnly]="false" [autoUpdateContent]="true" [durationBeforeCallback]="1000"
+          (textChanged)="onTextAreaChanged($event, question.key)" style="min-height: 200px; width: 100%"></div>
       </div>
 
       <div class="form-group">
         <div *ngSwitchCase="'searchbox'">
-          <app-concept
-            *ngIf="question.searchData == 'concept'"
-            [question]="question"
-            [form]="form"
-            (answers)="emitAnswers($event)"
-          ></app-concept>
-          <!--<app-order *ngIf="question.searchData == 'order'" [_question]="question" [_form]="form"></app-order>-->
+          <app-concept *ngIf="question.searchData === 'concept'" [question]="question" [form]="form"
+            (answers)="emitAnswers($event)"></app-concept>
+          <!--<app-order *ngIf="question.searchData === 'order'" [_question]="question" [_form]="form"></app-order>-->
         </div>
       </div>
     </div>

--- a/src/app/form-editor/element-editor/dynamic-question/dynamic-question.component.ts
+++ b/src/app/form-editor/element-editor/dynamic-question/dynamic-question.component.ts
@@ -36,18 +36,18 @@ export class DynamicQuestionComponent implements OnInit {
   }
 
   typeSelected(selectBox: string) {
-    if (selectBox == 'type') {
-      let value = this.form.controls['type'].value;
+    if (selectBox === 'type') {
+      const value = this.form.controls['type'].value;
       this.type.emit(value);
     }
 
-    if (selectBox == 'questionOptions.rendering') {
-      let value = this.form.controls['questionOptions.rendering'].value;
+    if (selectBox === 'questionOptions.rendering') {
+      const value = this.form.controls['questionOptions.rendering'].value;
       this.rendering.emit(value);
     }
 
-    if (selectBox == 'questionOptions.showDate') {
-      let value = this.form.controls['questionOptions.showDate'].value;
+    if (selectBox === 'questionOptions.showDate') {
+      const value = this.form.controls['questionOptions.showDate'].value;
       this.showDate.emit(value);
     }
   }

--- a/src/app/form-editor/element-editor/element-editor.component.html
+++ b/src/app/form-editor/element-editor/element-editor.component.html
@@ -14,45 +14,25 @@
 
     <div class="pull-right">
       <div class="dropdown" style="display: inline-block">
-        <a
-          class="btn btn-primary dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-          ><i class="fa fa-plus-circle fa-lg" aria-hidden="true"></i> Add
-          Property <span class="caret"></span
-        ></a>
+        <a class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"><i
+            class="fa fa-plus-circle fa-lg" aria-hidden="true"></i> Add
+          Property <span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li
-            (click)="addProperty(prop, prop.parentPath)"
-            *ngFor="let prop of allPossibleproperties"
-          >
-            <a [class.disabled]="prop.type == 'disabled'">{{ prop.label }}</a>
+          <li (click)="addProperty(prop, prop.parentPath)" *ngFor="let prop of allPossibleproperties">
+            <a [class.disabled]="prop.type === 'disabled'">{{ prop.label }}</a>
           </li>
         </ul>
       </div>
-      <div
-        *ngIf="setMembers.length > 0"
-        class="dropdown"
-        style="display: inline-block"
-      >
-        <a
-          class="btn btn-success dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-        >
-          Set Members <span class="caret"></span
-        ></a>
+      <div *ngIf="setMembers.length > 0" class="dropdown" style="display: inline-block">
+        <a class="btn btn-success dropdown-toggle" type="button" data-toggle="dropdown">
+          Set Members <span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li>
-            <a (click)="viewSetMembers()"
-              ><i class="fa fa-eye" aria-hidden="true"></i> View Set Members</a
-            >
+            <a (click)="viewSetMembers()"><i class="fa fa-eye" aria-hidden="true"></i> View Set Members</a>
           </li>
 
           <li>
-            <a (click)="reselectSetMembers()"
-              ><i class="fa fa-refresh"></i> Reselect Set Members</a
-            >
+            <a (click)="reselectSetMembers()"><i class="fa fa-refresh"></i> Reselect Set Members</a>
           </li>
         </ul>
       </div>
@@ -65,56 +45,34 @@
         <div *ngFor="let question of questions; let i = index">
           <div class="pull-right" *ngIf="checkQuestion(question)">
             <a (click)="deleteProp(i)" data-toggle="tooltip" title="Delete">
-              <i
-                class="fa fa-times"
-                style="
+              <i class="fa fa-times" style="
                   font-size: 16px;
                   margin: 5px;
                   color: red;
                   cursor: pointer;
-                "
-              ></i>
+                "></i>
             </a>
           </div>
 
-          <div
-            class="pull-right"
-            *ngIf="question.key == 'questionOptions.answers' && question.value"
-          >
-            <a
-              (click)="reselectAnswers()"
-              data-toggle="tooltip"
-              title="Reselect Answers"
-            >
-              <i
-                class="fa fa-undo"
-                style="
+          <div class="pull-right" *ngIf="question.key === 'questionOptions.answers' && question.value">
+            <a (click)="reselectAnswers()" data-toggle="tooltip" title="Reselect Answers">
+              <i class="fa fa-undo" style="
                   font-size: 16px;
                   margin: 5px;
                   color: green;
                   cursor: pointer;
-                "
-              ></i>
+                "></i>
             </a>
           </div>
 
-          <app-dynamic-question
-            [question]="question"
-            [_form]="form"
-            (answers)="setAnswers($event)"
-            (type)="typeSelected($event)"
-            (rendering)="renderingSelected($event)"
-            (showDate)="showDate($event)"
-          ></app-dynamic-question>
+          <app-dynamic-question [question]="question" [_form]="form" (answers)="setAnswers($event)"
+            (type)="typeSelected($event)" (rendering)="renderingSelected($event)" (showDate)="showDate($event)">
+          </app-dynamic-question>
         </div>
 
         <div class="form-row">
           <br />
-          <button
-            class="btn btn-primary btn-lg center-block"
-            (click)="onSubmit()"
-            [disabled]="!form.valid"
-          >
+          <button class="btn btn-primary btn-lg center-block" (click)="onSubmit()" [disabled]="!form.valid">
             OK
           </button>
         </div>

--- a/src/app/form-editor/element-editor/element-editor.component.ts
+++ b/src/app/form-editor/element-editor/element-editor.component.ts
@@ -260,7 +260,7 @@ export class ElementEditorComponent implements OnInit {
       const _id = this.form.get('id').value;
       const ids = this.qis.getIDs(this._rawSchema);
       let count = 0;
-      for (let $id of ids) {
+      for (const $id of ids) {
         if ($id === _id) {
           count++;
         }

--- a/src/app/form-editor/form-editor/form-editor-menu.component.ts
+++ b/src/app/form-editor/form-editor/form-editor-menu.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'form-editor-menu',
   templateUrl: './form-editor-menu.html',
   styleUrls: []

--- a/src/app/form-editor/form-editor/form-editor-menu.html
+++ b/src/app/form-editor/form-editor/form-editor-menu.html
@@ -1,125 +1,75 @@
 <div class="btn-group show-on-hover">
-  <button
-    type="button"
-    class="btn btn-default dropdown-toggle"
-    data-toggle="dropdown"
-  >
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="fb-menu-item">File</span>
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
       <a (click)="saveLocally()">
-        <span style="font-size: 14px; font-weight: 500"
-          ><i class="glyphicon glyphicon-save" aria-hidden="true"></i> Save
-          Locally</span
-        ></a
-      >
+        <span style="font-size: 14px; font-weight: 500"><i class="glyphicon glyphicon-save" aria-hidden="true"></i> Save
+          Locally</span></a>
     </li>
     <li>
       <a (click)="saveRemotely()">
-        <span style="margin-top: 15px; font-size: 14px; font-weight: 500"
-          ><i class="fa fa-server" aria-hidden="true"></i> Save to Server</span
-        ></a
-      >
+        <span style="margin-top: 15px; font-size: 14px; font-weight: 500"><i class="fa fa-server"
+            aria-hidden="true"></i> Save to Server</span></a>
     </li>
   </ul>
 </div>
 
 <div class="btn-group show-on-hover">
-  <button
-    type="button"
-    class="btn btn-default dropdown-toggle"
-    data-toggle="dropdown"
-  >
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="fb-menu-item">View</span>
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
-      <a (click)="toggleView()"
-        ><span style="font-size: 14px; font-weight: 500"
-          ><i class="fa fa-square-o" aria-hidden="true"></i> Single View</span
-        >
-        <i
-          class="fa"
-          [class.fa-check]="viewMode=='singleView'"
-          style="color: green"
-        ></i
-      ></a>
+      <a (click)="toggleView()"><span style="font-size: 14px; font-weight: 500"><i class="fa fa-square-o"
+            aria-hidden="true"></i> Single View</span>
+        <i class="fa" [class.fa-check]="viewMode === 'singleView'" style="color: green"></i></a>
     </li>
     <li>
-      <a (click)="toggleView()"
-        ><span style="font-size: 15px; font-weight: 500">
-          <i class="fa fa-columns" aria-hidden="true"></i> Split View</span
-        >
-        <i
-          class="fa"
-          [class.fa-check]="viewMode=='multiView'"
-          style="color: green"
-        ></i
-      ></a>
+      <a (click)="toggleView()"><span style="font-size: 15px; font-weight: 500">
+          <i class="fa fa-columns" aria-hidden="true"></i> Split View</span>
+        <i class="fa" [class.fa-check]="viewMode === 'multiView'" style="color: green"></i></a>
     </li>
   </ul>
 </div>
 
 <div class="btn-group show-on-hover">
-  <button
-    type="button"
-    class="btn btn-default dropdown-toggle"
-    data-toggle="dropdown"
-  >
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="fb-menu-item">Tasks</span>
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
-      <a (click)="validateConcepts()"
-        ><i class="fa fa-check-square-o"></i>
+      <a (click)="validateConcepts()"><i class="fa fa-check-square-o"></i>
         <span style="font-size: 14px; font-weight: 500">
-          Validate Concepts</span
-        ></a
-      >
+          Validate Concepts</span></a>
     </li>
     <li>
-      <a (click)="validateConcepts()"
-        ><i class="fa fa-check-square-o"></i>
+      <a (click)="validateConcepts()"><i class="fa fa-check-square-o"></i>
         <span style="font-size: 14px; font-weight: 500">
-          Validate Concepts</span
-        ></a
-      >
+          Validate Concepts</span></a>
     </li>
   </ul>
 </div>
 
 <div class="btn-group show-on-hover">
-  <button
-    type="button"
-    class="btn btn-default dropdown-toggle"
-    data-toggle="dropdown"
-  >
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
     <span class="fb-menu-item">User</span>
   </button>
   <ul class="dropdown-menu" role="menu">
     <li>
       <a>
-        <span class="fa fa-user"></span
-        ><span style="font-size: 14px; font-weight: 500"> {{user}}</span></a
-      >
+        <span class="fa fa-user"></span><span style="font-size: 14px; font-weight: 500"> {{user}}</span></a>
     </li>
     <li>
       <a>
-        <i class="fa fa-server"></i
-        ><span style="font-size: 14px; font-weight: 500"></span> {{url}}</a
-      >
+        <i class="fa fa-server"></i><span style="font-size: 14px; font-weight: 500"></span> {{url}}</a>
     </li>
   </ul>
 </div>
 
 <div class="btn-group">
-  <button
-    type="button"
-    class="btn btn-default"
-    data-toggle="collapse"
-    data-target="#audit-info"
-  >
+  <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#audit-info">
     <span class="fb-menu-item">Audit</span>
   </button>
 </div>

--- a/src/app/form-editor/form-editor/form-editor.component.html
+++ b/src/app/form-editor/form-editor/form-editor.component.html
@@ -6,13 +6,8 @@
     <mat-sidenav #sidenav mode="over" class="app-sidenav">
       <!---Navigator-->
 
-      <app-navigator
-        [_rawSchema]="rawSchema"
-        [_schema]="schema"
-        [formSchema]="schema"
-        [mode]="'edit'"
-        (closeSidebar)="closeNavigator($event)"
-      ></app-navigator>
+      <app-navigator [_rawSchema]="rawSchema" [_schema]="schema" [formSchema]="schema" [mode]="'edit'"
+        (closeSidebar)="closeNavigator($event)"></app-navigator>
     </mat-sidenav>
     <mat-toolbar color="primary">
       <button mat-icon-button (click)="sidenav.toggle()">
@@ -21,134 +16,83 @@
       <span style="font-size: 18px; font-family: 'Roboto'">Form Builder</span>
       <span class="menu">
         <div class="btn-group show-on-hover">
-          <button
-            type="button"
-            class="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-          >
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             <span class="fb-menu-item">File</span>
           </button>
           <ul class="dropdown-menu" role="menu">
             <li>
               <a (click)="saveLocally()">
-                <span style="font-size: 14px; font-weight: 500"
-                  ><i class="glyphicon glyphicon-save" aria-hidden="true"></i>
-                  Save Locally</span
-                ></a
-              >
+                <span style="font-size: 14px; font-weight: 500"><i class="glyphicon glyphicon-save"
+                    aria-hidden="true"></i>
+                  Save Locally</span></a>
             </li>
             <li>
               <a (click)="saveRemotely()">
-                <span
-                  style="margin-top: 15px; font-size: 14px; font-weight: 500"
-                  ><i class="fa fa-server" aria-hidden="true"></i> Save to
-                  Server</span
-                ></a
-              >
+                <span style="margin-top: 15px; font-size: 14px; font-weight: 500"><i class="fa fa-server"
+                    aria-hidden="true"></i> Save to
+                  Server</span></a>
             </li>
           </ul>
         </div>
 
         <div class="btn-group show-on-hover">
-          <button
-            type="button"
-            class="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-          >
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             <span class="fb-menu-item">View</span>
           </button>
           <ul class="dropdown-menu" role="menu">
             <li>
-              <a (click)="toggleView()"
-                ><span style="font-size: 14px; font-weight: 500"
-                  ><i class="fa fa-square-o" aria-hidden="true"></i> Single
-                  View</span
-                >
-                <i
-                  class="fa"
-                  [class.fa-check]="viewMode == 'singleView'"
-                  style="color: green"
-                ></i
-              ></a>
+              <a (click)="toggleView()"><span style="font-size: 14px; font-weight: 500"><i class="fa fa-square-o"
+                    aria-hidden="true"></i> Single
+                  View</span>
+                <i class="fa" [class.fa-check]="viewMode === 'singleView'" style="color: green"></i></a>
             </li>
             <li>
-              <a (click)="toggleView()"
-                ><span style="font-size: 15px; font-weight: 500">
+              <a (click)="toggleView()"><span style="font-size: 15px; font-weight: 500">
                   <i class="fa fa-columns" aria-hidden="true"></i> Split
-                  View</span
-                >
-                <i
-                  class="fa"
-                  [class.fa-check]="viewMode == 'multiView'"
-                  style="color: green"
-                ></i
-              ></a>
+                  View</span>
+                <i class="fa" [class.fa-check]="viewMode === 'multiView'" style="color: green"></i></a>
             </li>
           </ul>
         </div>
 
         <div class="btn-group show-on-hover">
-          <button
-            type="button"
-            class="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-          >
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             <span class="fb-menu-item">Tasks</span>
           </button>
           <ul class="dropdown-menu" role="menu">
             <li>
-              <a (click)="validateConcepts()"
-                ><i class="fa fa-check-square-o"></i>
+              <a (click)="validateConcepts()"><i class="fa fa-check-square-o"></i>
                 <span style="font-size: 14px; font-weight: 500">
-                  Validate Concepts</span
-                ></a
-              >
+                  Validate Concepts</span></a>
             </li>
             <li>
-              <a (click)="addConceptMappingsToForm(rawSchema)"
-                ><i class="fa fa-plus-circle"></i>
+              <a (click)="addConceptMappingsToForm(rawSchema)"><i class="fa fa-plus-circle"></i>
                 <span style="font-size: 14px; font-weight: 500">
-                  Add Concept Mappings to Schema</span
-                ></a
-              >
+                  Add Concept Mappings to Schema</span></a>
             </li>
           </ul>
         </div>
 
         <div class="btn-group show-on-hover">
-          <button
-            type="button"
-            class="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-          >
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             <span class="fb-menu-item">User</span>
           </button>
           <ul class="dropdown-menu" role="menu">
             <li>
               <a>
-                <span class="fa fa-user"></span
-                ><span style="font-size: 14px; font-weight: 500">
-                  {{ user }}</span
-                ></a
-              >
+                <span class="fa fa-user"></span><span style="font-size: 14px; font-weight: 500">
+                  {{ user }}</span></a>
             </li>
             <li>
               <a>
-                <i class="fa fa-server"></i
-                ><span style="font-size: 14px; font-weight: 500"></span>
-                {{ url }}</a
-              >
+                <i class="fa fa-server"></i><span style="font-size: 14px; font-weight: 500"></span>
+                {{ url }}</a>
             </li>
           </ul>
         </div>
 
         <div class="btn-group">
-          <button
-            type="button"
-            class="btn btn-default"
-            data-toggle="collapse"
-            data-target="#audit-info"
-          >
+          <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#audit-info">
             <span class="fb-menu-item">Audit</span>
           </button>
         </div>
@@ -162,20 +106,10 @@
       <span flex></span>
       <app-reference-forms [schema]="schema"></app-reference-forms>
       <span class="space"></span>
-      <button
-        *ngIf="!formMetadata.published"
-        type="button"
-        class="btn btn-info"
-        (click)="publish()"
-      >
+      <button *ngIf="!formMetadata.published" type="button" class="btn btn-info" (click)="publish()">
         Publish
       </button>
-      <button
-        *ngIf="formMetadata.published"
-        type="button"
-        class="btn btn-danger"
-        (click)="unpublish()"
-      >
+      <button *ngIf="formMetadata.published" type="button" class="btn btn-danger" (click)="unpublish()">
         Unpublish
       </button>
     </mat-toolbar>
@@ -186,47 +120,30 @@
     </div>
 
     <div class="app-content" *ngIf="schema">
-      <div *ngIf="viewMode == 'singleView'">
+      <div *ngIf="viewMode === 'singleView'">
         <mat-tab-group mat-stretch-tabs class="schema-editor">
           <!--Element Editor-->
           <mat-tab *ngIf="questions" label="Element Editor">
             <ng-template mat-tab-label>
               Question Editor
-              <a
-                (click)="closeElementEditor()"
-                data-toggle="tooltip"
-                title="close tab"
-                class="pull-right"
-                style="margin-right: 25px; padding-top: 5px; cursor: pointer"
-                ><i class="material-icons">highlight_off</i></a
-              >
+              <a (click)="closeElementEditor()" data-toggle="tooltip" title="close tab" class="pull-right"
+                style="margin-right: 25px; padding-top: 5px; cursor: pointer"><i
+                  class="material-icons">highlight_off</i></a>
             </ng-template>
 
             <mat-card class="element-editor">
-              <app-element-editor
-                [schema]="schema"
-                [pageIndex]="page"
-                [sectionIndex]="section"
-                [questionIndex]="question"
-                [parentQuestionIndex]="parentQuestionIndex"
-                [_questions]="questions"
-                [rawSchema]="rawSchema"
-                (closeComponent)="closeElementEditor()"
-                [questionSchema]="questionSchema"
-              ></app-element-editor>
+              <app-element-editor [schema]="schema" [pageIndex]="page" [sectionIndex]="section"
+                [questionIndex]="question" [parentQuestionIndex]="parentQuestionIndex" [_questions]="questions"
+                [rawSchema]="rawSchema" (closeComponent)="closeElementEditor()" [questionSchema]="questionSchema">
+              </app-element-editor>
             </mat-card>
           </mat-tab>
 
           <!--Schema editor-->
           <mat-tab label="Schema Editor">
             <mat-card class="schema-editor">
-              <app-schema-editor
-                [schema]="schema"
-                [rawSchema]="rawSchema"
-                [$formSchema]="schema"
-                [strRawSchema]="strRawSchema"
-                [strSchema]="strSchema"
-              ></app-schema-editor>
+              <app-schema-editor [schema]="schema" [rawSchema]="rawSchema" [$formSchema]="schema"
+                [strRawSchema]="strRawSchema" [strSchema]="strSchema"></app-schema-editor>
             </mat-card>
           </mat-tab>
 
@@ -239,7 +156,7 @@
         </mat-tab-group>
       </div>
 
-      <div *ngIf="viewMode == 'multiView'">
+      <div *ngIf="viewMode === 'multiView'">
         <div class="row">
           <!--Element Editor-->
           <div *ngIf="questions" class="col-md-4">
@@ -247,27 +164,15 @@
               <h4 class="text-cente" style="display: inline-block">
                 Question Editor
               </h4>
-              <a
-                (click)="closeElementEditor()"
-                data-toggle="tooltip"
-                title="close tab"
-                class="pull-right"
-                style="padding-top: 5px; cursor: pointer; display: inline-block"
-                ><i class="material-icons">highlight_off</i></a
-              >
+              <a (click)="closeElementEditor()" data-toggle="tooltip" title="close tab" class="pull-right"
+                style="padding-top: 5px; cursor: pointer; display: inline-block"><i
+                  class="material-icons">highlight_off</i></a>
             </div>
 
             <mat-card class="element-editor">
-              <app-element-editor
-                [schema]="schema"
-                [pageIndex]="page"
-                [sectionIndex]="section"
-                [questionIndex]="question"
-                [parentQuestionIndex]="parentQuestionIndex"
-                [_questions]="questions"
-                [rawSchema]="rawSchema"
-                (closeComponent)="closeElementEditor()"
-              ></app-element-editor>
+              <app-element-editor [schema]="schema" [pageIndex]="page" [sectionIndex]="section"
+                [questionIndex]="question" [parentQuestionIndex]="parentQuestionIndex" [_questions]="questions"
+                [rawSchema]="rawSchema" (closeComponent)="closeElementEditor()"></app-element-editor>
             </mat-card>
           </div>
 
@@ -275,11 +180,8 @@
           <div [class.col-md-4]="questions" [class.col-md-6]="!questions">
             <h4 class="text-center">Schema Editor</h4>
             <mat-card class="schema-editor">
-              <app-schema-editor
-                [schema]="strSchema"
-                [rawSchema]="strRawSchema"
-                [$formSchema]="schema"
-              ></app-schema-editor>
+              <app-schema-editor [schema]="strSchema" [rawSchema]="strRawSchema" [$formSchema]="schema">
+              </app-schema-editor>
             </mat-card>
           </div>
 
@@ -295,22 +197,16 @@
     </div>
   </mat-sidenav-container>
 </div>
-<div *ngIf="viewMode == 'badSchema' && !schema">
+<div *ngIf="viewMode === 'badSchema' && !schema">
   <mat-toolbar class="errorToolbar">
-    <span style="font-size: 18px; font-family: 'Roboto'; color: white"
-      >Form Builder</span
-    >
+    <span style="font-size: 18px; font-family: 'Roboto'; color: white">Form Builder</span>
   </mat-toolbar>
   <span class="alert alert-warning">
     This schema contains errors and cannot be properly compiled. Please try to
     correct the errors in the schema and re-compile it.
   </span>
   <div class="well">
-    <app-schema-editor
-      [strRawSchema]="strRawSchema"
-      [correctionMode]="true"
-      [_errorMessage]="errorMessage"
-      (correctedSchemaErrors)="loadFormBuilder($event)"
-    ></app-schema-editor>
+    <app-schema-editor [strRawSchema]="strRawSchema" [correctionMode]="true" [_errorMessage]="errorMessage"
+      (correctedSchemaErrors)="loadFormBuilder($event)"></app-schema-editor>
   </div>
 </div>

--- a/src/app/form-editor/form-editor/form-editor.component.ts
+++ b/src/app/form-editor/form-editor/form-editor.component.ts
@@ -190,7 +190,7 @@ export class FormEditorComponent
             }
             this.formMetadata.auditInfo = metadata.auditInfo;
             this.formMetadata.published = metadata.published;
-            // this.saveFormMetadata(this.formMetadata); //save form metadata to local storage for retrieval later on
+            // this.saveFormMetadata(this.formMetadata); // save form metadata to local storage for retrieval later on
             if (metadata.resources.length) {
               this.formMetadata.valueReference =
                 metadata.resources[0].valueReference || '';

--- a/src/app/form-editor/form-renderer/mock-obs.ts
+++ b/src/app/form-editor/form-renderer/mock-obs.ts
@@ -42,11 +42,13 @@ export class MockObs {
               {
                 rel: 'self',
                 uri:
+                  // tslint:disable-next-line:max-line-length
                   'https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/patient/dbb2f104-82f3-4fa9-aaaa-3b0ea908f936/identifier/cae5f716-e7f0-4851-a348-7ed27be2cd28'
               },
               {
                 rel: 'full',
                 uri:
+                  // tslint:disable-next-line:max-line-length
                   'https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/patient/dbb2f104-82f3-4fa9-aaaa-3b0ea908f936/identifier/cae5f716-e7f0-4851-a348-7ed27be2cd28?v=full'
               }
             ],

--- a/src/app/form-editor/models/property-factory.ts
+++ b/src/app/form-editor/models/property-factory.ts
@@ -10,13 +10,16 @@ export class PropertyFactory {
   constructor() {}
 
   createProperty(type: string, options: {}): PropertyModel<any> {
-    if (type.toLowerCase() === 'textbox') return new TextboxProperty(options);
-    else if (type.toLowerCase() === 'select')
+    if (type.toLowerCase() === 'textbox') {
+      return new TextboxProperty(options);
+    } else if (type.toLowerCase() === 'select') {
       return new SelectProperty(options);
-    else if (type.toLowerCase() === 'searchbox')
+    } else if (type.toLowerCase() === 'searchbox') {
       return new SearchboxProperty(options);
-    else if (type.toLowerCase() === 'textarea')
+    } else if (type.toLowerCase() === 'textarea') {
       return new TextAreaProperty(options);
-    else console.log('No such property exists');
+    } else {
+      console.log('No such property exists');
+    }
   }
 }

--- a/src/app/form-editor/navigator/navigator.component.ts
+++ b/src/app/form-editor/navigator/navigator.component.ts
@@ -115,7 +115,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.editMode = true;
       this.selectMode = false;
       this.updateMode = false;
-    } else if (this.mode == 'update') {
+    } else if (this.mode === 'update') {
       this.selectMode = false;
       this.editMode = false;
       this.updateMode = true;
@@ -125,7 +125,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.updateMode = false;
     }
     this.subscription = this.ns.getExcludedQuestions().subscribe((res) => {
-      if (res != '') {
+      if (res !== '') {
         this.excludedQuestions.push(res);
       } else {
         this.excludedQuestions = [];
@@ -154,7 +154,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     if (this.selectMode) {
       return;
     }
-    let schemaObj = {};
+    const schemaObj = {};
     schemaObj['selectedSchema'] = selectedSchema;
     schemaObj['pageIndex'] = pageIndex;
     schemaObj['sectionIndex'] = sectionIndex;
@@ -162,10 +162,10 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     this.ns.setClickedElementSchema(schemaObj);
 
     if (
-      pageIndex != undefined &&
-      sectionIndex != undefined &&
-      questionIndex != undefined &&
-      parentQuestionIndex != undefined
+      pageIndex !== undefined &&
+      sectionIndex !== undefined &&
+      questionIndex !== undefined &&
+      parentQuestionIndex !== undefined
     ) {
       if (this.rawSchema.pages[pageIndex].label) {
         if (this.rawSchema.pages[pageIndex].sections[sectionIndex].label) {
@@ -185,9 +185,9 @@ export class NavigatorComponent implements OnInit, OnDestroy {
         this.ns.setClickedElementRawSchema(this.rawSchema.pages[pageIndex]);
       }
     } else if (
-      pageIndex != undefined &&
-      sectionIndex != undefined &&
-      questionIndex != undefined
+      pageIndex !== undefined &&
+      sectionIndex !== undefined &&
+      questionIndex !== undefined
     ) {
       if (this.rawSchema.pages[pageIndex].label) {
         if (this.rawSchema.pages[pageIndex].sections[sectionIndex].label) {
@@ -207,7 +207,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
         this.ns.setClickedElementRawSchema(this.rawSchema.pages[pageIndex]);
         return;
       }
-    } else if (pageIndex != undefined && sectionIndex != undefined) {
+    } else if (pageIndex !== undefined && sectionIndex !== undefined) {
       if (this.rawSchema.pages[pageIndex].label) {
         this.ns.setClickedElementRawSchema(
           this.rawSchema.pages[pageIndex].sections[sectionIndex]
@@ -243,8 +243,8 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   }
 
   showAddForm(element: string, pageIndex?: number) {
-    if (element == 'page') {
-      let newPage = this.formElementFactory.createFormElement(element, {
+    if (element === 'page') {
+      const newPage = this.formElementFactory.createFormElement(element, {
         label: ''
       });
       this.propertyModelArray = this.qcs.toPropertyModelArray(newPage);
@@ -252,7 +252,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.showAddDialog(this.propertyModelArray, this.addForm);
     } else {
       console.log(pageIndex);
-      let newSection = this.formElementFactory.createFormElement(element, {});
+      const newSection = this.formElementFactory.createFormElement(element, {});
       this.propertyModelArray = this.qcs.toPropertyModelArray(newSection);
       this.addForm = this.qcs.toFormGroup(this.propertyModelArray);
       this.showAddDialog(this.propertyModelArray, this.addForm, pageIndex);
@@ -280,22 +280,24 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       )
       .subscribe((isConfirmed) => {
         if (isConfirmed) {
-          if (element == 'page') this.deletePage(pageIndex);
-          else if (element == 'section')
+          if (element === 'page') {
+            this.deletePage(pageIndex);
+          } else if (element === 'section') {
             this.deleteSection(pageIndex, sectionIndex);
-          else
+          } else {
             this.deleteQuestion(
               pageIndex,
               sectionIndex,
               questionIndex,
               parentQuestionIndex
             );
+          }
         }
       });
   }
 
   showEditDialog(propModelArray, form, pageIndex, sectionIndex?) {
-    if (sectionIndex > -1)
+    if (sectionIndex > -1) {
       this.subscription = this.dialogService
         .addDialog(PromptComponent, {
           title: 'Edit Section',
@@ -303,9 +305,11 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           form: form
         })
         .subscribe((formValue) => {
-          if (formValue) this.editSection(formValue, pageIndex, sectionIndex);
+          if (formValue) {
+            this.editSection(formValue, pageIndex, sectionIndex);
+          }
         });
-    else
+    } else {
       this.subscription = this.dialogService
         .addDialog(PromptComponent, {
           title: 'Edit Page',
@@ -313,12 +317,15 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           form: form
         })
         .subscribe((formValue) => {
-          if (formValue) this.editPage(formValue['label'], pageIndex);
+          if (formValue) {
+            this.editPage(formValue['label'], pageIndex);
+          }
         });
+    }
   }
 
   showAddDialog(propModelArray, form, pageIndex?) {
-    if (pageIndex != undefined && pageIndex > -1) {
+    if (pageIndex !== undefined && pageIndex > -1) {
       this.subscription = this.dialogService
         .addDialog(
           PromptComponent,
@@ -332,9 +339,11 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           }
         )
         .subscribe((formValue) => {
-          if (formValue != undefined) this.addSection(formValue, pageIndex);
+          if (formValue !== undefined) {
+            this.addSection(formValue, pageIndex);
+          }
         });
-    } else
+    } else {
       this.subscription = this.dialogService
         .addDialog(
           PromptComponent,
@@ -348,8 +357,11 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           }
         )
         .subscribe((formValue) => {
-          if (formValue) this.addPage(formValue['label']);
+          if (formValue) {
+            this.addPage(formValue['label']);
+          }
         });
+    }
   }
 
   editPage(label, pageIndex) {
@@ -390,7 +402,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     questionIndex: number,
     parentQuestionIndex?: number
   ) {
-    let schemaObj = {};
+    const schemaObj = {};
     schemaObj['selectedSchema'] = question;
     schemaObj['pageIndex'] = pageIndex;
     schemaObj['sectionIndex'] = sectionIndex;
@@ -399,7 +411,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     this.ns.setClickedElementSchema(schemaObj); // set the current edited question in the schema editor
 
     this.propertyModelArray = this.qcs.toPropertyModelArray(question);
-    if (parentQuestionIndex != undefined && parentQuestionIndex > -1) {
+    if (parentQuestionIndex !== undefined && parentQuestionIndex > -1) {
       // thy art an obsgroup question!
       this.ns.newQuestion(
         this.propertyModelArray,
@@ -422,7 +434,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
 
   addPage(label: string) {
     if (!this.doesPageExist(label)) {
-      let newPage = this.formElementFactory.createFormElement('page', {
+      const newPage = this.formElementFactory.createFormElement('page', {
         label: label
       });
       this.rawSchema.pages.push(newPage);
@@ -430,14 +442,15 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.ns.setSchema(this._formSchema);
       this.ns.setRawSchema(this.rawSchema);
       this.onClicked(newPage, this.rawSchema.pages.length - 1);
-    } else
+    } else {
       this.showAlertDialog(
         'Page already exists! \n Try creating one with a different label!'
       );
+    }
   }
 
   addSection(value, pageIndex: number) {
-    let newSection = this.formElementFactory.createFormElement('section', {
+    const newSection = this.formElementFactory.createFormElement('section', {
       label: value.label,
       isExpanded: value.isExpanded
     });
@@ -466,9 +479,12 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       'questionIndex',
       questionIndex
     );
-    let newQuestion = this.formElementFactory.createFormElement('question', {});
-    let propertyModelArray = this.qcs.toPropertyModelArray(newQuestion);
-    if (questionIndex != undefined) {
+    const newQuestion = this.formElementFactory.createFormElement(
+      'question',
+      {}
+    );
+    const propertyModelArray = this.qcs.toPropertyModelArray(newQuestion);
+    if (questionIndex !== undefined) {
       this.ns.newQuestion(
         propertyModelArray,
         pageIndex,
@@ -545,7 +561,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   }
 
   addReferencePage() {
-    if (this.referencedForms.length > 0)
+    if (this.referencedForms.length > 0) {
       this.subscription = this.dialogService
         .addDialog(
           ReferenceModalComponent,
@@ -557,16 +573,18 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           }
         )
         .subscribe((res) => {
-          if (res != undefined) {
+          if (res !== undefined) {
             this.createRefPages(JSON.parse(res));
           }
         });
-    else this.showAlertDialog('Insert reference form first');
+    } else {
+      this.showAlertDialog('Insert reference form first');
+    }
   }
 
   addReferenceSection(pageIndex) {
     this.ns.setExcludedQuestions('');
-    if (this.referencedForms.length > 0)
+    if (this.referencedForms.length > 0) {
       this.subscription = this.dialogService
         .addDialog(
           ReferenceModalComponent,
@@ -578,15 +596,17 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           }
         )
         .subscribe((res) => {
-          if (res != undefined) {
+          if (res !== undefined) {
             this.createRefSections(JSON.parse(res), pageIndex);
           }
         });
-    else this.showAlertDialog('Insert reference form first');
+    } else {
+      this.showAlertDialog('Insert reference form first');
+    }
   }
 
   addReferenceQuestion(pageIndex, sectionIndex, questionIndex?) {
-    if (this.referencedForms.length > 0)
+    if (this.referencedForms.length > 0) {
       this.subscription = this.dialogService
         .addDialog(
           ReferenceModalComponent,
@@ -598,10 +618,11 @@ export class NavigatorComponent implements OnInit, OnDestroy {
           }
         )
         .subscribe((res) => {
-          if (res != undefined) {
+          if (res !== undefined) {
             // this.createRefQuestions(JSON.parse(res),pageIndex,sectionIndex,questionIndex)
           }
         });
+    }
   }
 
   setCheckedReferenceElement(event, element?) {
@@ -620,12 +641,15 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.checkedRefElements.push(el);
     } else {
       if (this.checkedRefElements.length > 0) {
-        this.checkedRefElements.forEach((element, index) => {
-          if (typeof element != 'object' && element == el) {
+        this.checkedRefElements.forEach((checkedRefElement, index) => {
+          if (
+            typeof checkedRefElement !== 'object' &&
+            checkedRefElement === el
+          ) {
             this.checkedRefElements.splice(index, 1);
           } else if (
-            typeof element == 'object' &&
-            JSON.stringify(el) === JSON.stringify(element)
+            typeof checkedRefElement === 'object' &&
+            JSON.stringify(el) === JSON.stringify(checkedRefElement)
           ) {
             this.checkedRefElements.splice(index, 1);
           }
@@ -633,12 +657,13 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (this.schema['pages'])
+    if (this.schema['pages']) {
       this.checkedRefElementsEmitter.emit(this.checkedRefElements);
+    }
   }
 
   emitCheckedReferenceElement(event, element) {
-    let e = {};
+    const e = {};
     e['event'] = event;
     e['element'] = element;
     this.nestedCheckedRefElementEmitter.emit(e);
@@ -649,10 +674,9 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   }
 
   createRefPages(res) {
-    let formProps = this.createBasicFormProps();
-    let tempSchema: Object;
+    const formProps = this.createBasicFormProps();
 
-    for (var el of JSON.parse(res['Pages'])) {
+    for (const el of JSON.parse(res['Pages'])) {
       let obj: any = {};
       obj['reference'] = {
         form: res.form,
@@ -665,8 +689,8 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       this.rawSchema.pages.push(JSON.parse(obj));
     }
 
-    let mockForm = this.formFactory.createForm(formProps);
-    let compiledForm = this.fsc.compileFormSchema(
+    const mockForm = this.formFactory.createForm(formProps);
+    const compiledForm = this.fsc.compileFormSchema(
       mockForm,
       this.referencedForms
     );
@@ -685,9 +709,9 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   }
 
   createRefSections(res, pageIndex) {
-    let formProps = this.createBasicFormProps(pageIndex);
-    let formAlias = res.form;
-    for (var el of JSON.parse(res['Sections'])) {
+    const formProps = this.createBasicFormProps(pageIndex);
+    const formAlias = res.form;
+    for (const el of JSON.parse(res['Sections'])) {
       let obj: any = {};
       if (this.excludedQuestions.length > 0) {
         obj['reference'] = {
@@ -713,28 +737,30 @@ export class NavigatorComponent implements OnInit, OnDestroy {
         );
         return false;
       } else {
-        if (!this.sectionExist(pageIndex, JSON.parse(obj).reference.section))
+        if (!this.sectionExist(pageIndex, JSON.parse(obj).reference.section)) {
           this.rawSchema.pages[pageIndex].sections.push(JSON.parse(obj));
+        }
       }
     }
-    let mockForm = this.formFactory.createForm(formProps);
-    let compiledForm = this.fsc.compileFormSchema(
+    const mockForm = this.formFactory.createForm(formProps);
+    const compiledForm = this.fsc.compileFormSchema(
       mockForm,
       this.referencedForms
     );
 
     compiledForm['pages'][0]['sections'].forEach((section) => {
-      if (!this.sectionExist(pageIndex, section.label))
+      if (!this.sectionExist(pageIndex, section.label)) {
         this._formSchema.pages[pageIndex].sections.push(section);
+      }
     });
     this.setSchema(this._formSchema);
     this.setRawSchema(this.rawSchema);
   }
 
   sectionExist(pageIndex, sectionlabel) {
-    let exist: boolean = false;
+    let exist = false;
     this._formSchema.pages[pageIndex].sections.forEach((section) => {
-      if (section.label == sectionlabel) {
+      if (section.label === sectionlabel) {
         exist = true;
       }
     });
@@ -768,14 +794,14 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   // }
 
   createBasicFormProps(pageIndex?, sectionIndex?) {
-    let formProps = {};
+    const formProps = {};
     formProps['name'] = this.rawSchema.name;
     formProps['uuid'] = this.rawSchema.uuid;
     formProps['processor'] = this.rawSchema.processor;
     formProps['referencedForms'] = this.rawSchema.referencedForms;
     formProps['pages'] = [];
 
-    if (pageIndex != undefined && sectionIndex != undefined) {
+    if (pageIndex !== undefined && sectionIndex !== undefined) {
       formProps['pages'].push(
         this.formElementFactory.createFormElement('page', {
           label: this._formSchema.pages[pageIndex].label
@@ -804,10 +830,10 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   }
 
   addExcludedQuestions(res, el) {
-    let exQ = this.excludedQuestions;
-    let formAlias = res;
-    let final = [];
-    let acceptedQuestionIds = [];
+    const exQ = this.excludedQuestions;
+    const formAlias = res;
+    const final = [];
+    const acceptedQuestionIds = [];
     let referencedFormDits = [];
 
     this.fs.getReferencedFormsDetails().subscribe((dits) => {
@@ -815,12 +841,12 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       referencedFormDits.forEach((form) => {
         if ((form.alias = formAlias)) {
           this.referencedForms.forEach((form$, index) => {
-            if (form$.name == form.formName) {
+            if (form$.name === form.formName) {
               form$.pages.forEach((page, pageIndex) => {
-                if (page.label == el.page) {
+                if (page.label === el.page) {
                   form$.pages[pageIndex].sections.forEach(
                     (section, sectionIndex) => {
-                      if (section.label == el.section) {
+                      if (section.label === el.section) {
                         form$.pages[pageIndex].sections[
                           sectionIndex
                         ].questions.forEach((question) => {
@@ -841,7 +867,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
 
     acceptedQuestionIds.forEach((questionID) => {
       exQ.forEach((excludedQuestionId) => {
-        if (excludedQuestionId == questionID) {
+        if (excludedQuestionId === questionID) {
           final.push(excludedQuestionId);
         }
       });
@@ -856,7 +882,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     parentQuestionIndex,
     questionID
   ) {
-    if (parentQuestionIndex != undefined) {
+    if (parentQuestionIndex !== undefined) {
       this._formSchema.pages[pageIndex].sections[sectionIndex].questions[
         parentQuestionIndex
       ].questions.splice(questionIndex, 1);
@@ -878,7 +904,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
 
   findAndReplaceReferenceFormByName(name: string, schema: Object) {
     this.referencedForms.forEach((form, index) => {
-      if (form.name == name) {
+      if (form.name === name) {
         this.referencedForms.splice(index, 1, schema);
       }
     });
@@ -916,12 +942,10 @@ export class NavigatorComponent implements OnInit, OnDestroy {
   showSpinner() {
     try {
       if (!_.isEmpty(this._formSchema.pages)) {
-        let lastPageIndex = this._formSchema.pages.length - 1;
-
+        const lastPageIndex = this._formSchema.pages.length - 1;
         if (!_.isEmpty(this._formSchema.pages[lastPageIndex].sections)) {
-          let lastSectionIndex =
+          const lastSectionIndex =
             this._formSchema.pages[lastPageIndex].sections.length - 1;
-
           if (
             this._formSchema.pages[lastPageIndex].sections[lastSectionIndex]
           ) {
@@ -929,7 +953,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
               this._formSchema.pages[lastPageIndex].sections[lastSectionIndex]
                 .questions
             ) {
-              let lastQuestionIndex =
+              const lastQuestionIndex =
                 this._formSchema.pages[lastPageIndex].sections[lastSectionIndex]
                   .questions.length - 1;
               this.fs.setLoaded(true);
@@ -977,14 +1001,17 @@ export class NavigatorComponent implements OnInit, OnDestroy {
     let section: any = {};
     if (!this.IsPageReferenced(pageIndex)) {
       section = this.rawSchema.pages[pageIndex].sections[sectionIndex];
-      if (section.reference) result = true;
-      else result = true;
+      if (section.reference) {
+        result = true;
+      } else {
+        result = true;
+      }
     }
     return result;
   }
 
   editReferenceSection(pageIndex, sectionIndex: any) {
-    let section = this.rawSchema.pages[pageIndex].sections[sectionIndex];
+    const section = this.rawSchema.pages[pageIndex].sections[sectionIndex];
 
     this.ns.setPrechecked(section.reference.section);
     _.forEach(this.rawSchema.referencedForms, (form: any) => {
@@ -1007,7 +1034,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
                 )
                 .subscribe((res) => {
                   console.log(typeof res);
-                  if (res)
+                  if (res) {
                     this.createRefSections(
                       {
                         form: form.alias,
@@ -1015,6 +1042,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
                       },
                       pageIndex
                     );
+                  }
                 });
             });
         });
@@ -1027,8 +1055,7 @@ export class NavigatorComponent implements OnInit, OnDestroy {
       k,
       1
     );
-    let section = this.rawSchema.pages[pageIndex].sections[sectionIndex];
-    let newSection = '';
+    const section = this.rawSchema.pages[pageIndex].sections[sectionIndex];
     if (this.isSectionCustomized(section)) {
       this.rawSchema.pages[pageIndex].sections[
         sectionIndex
@@ -1058,14 +1085,15 @@ export class NavigatorComponent implements OnInit, OnDestroy {
 
     if (this.updateMode) {
       if (this.IsPageReferenced(pageIndex)) {
-        if (this.rawSchema.pages[pageIndex].reference.form == this.alias)
+        if (this.rawSchema.pages[pageIndex].reference.form === this.alias) {
           return true;
+        }
       }
 
       if (!_.isEmpty(sections)) {
         _.each(sections, (section) => {
           if (!section.label) {
-            if (section.reference.form == this.alias) {
+            if (section.reference.form === this.alias) {
               result = true;
             }
           }

--- a/src/app/form-editor/reference-forms/reference-forms.component.ts
+++ b/src/app/form-editor/reference-forms/reference-forms.component.ts
@@ -25,8 +25,7 @@ export class ReferenceFormsComponent implements OnInit {
   _schema: any;
   private _rawSchema: any;
   private componentForms: any;
-  private refForm: ReferenceForms = new ReferenceForms(); //the one being inserted
-  private st: string = '';
+  private refForm: ReferenceForms = new ReferenceForms(); // the one being inserted
   private refFormsArray: any[];
   @Input() set schema(schema) {
     this._schema = _.cloneDeep(schema);
@@ -85,7 +84,7 @@ export class ReferenceFormsComponent implements OnInit {
       this._rawSchema.referencedForms.push(refForm);
       this.fs.setReferencedFormsDetails(this._schema.referencedForms);
     } else {
-      let newOrderedSchema = {};
+      const newOrderedSchema = {};
       newOrderedSchema['name'] = this._schema.name;
       newOrderedSchema['uuid'] = this._schema.uuid;
       newOrderedSchema['processor'] = this._schema.processor;
@@ -112,7 +111,7 @@ export class ReferenceFormsComponent implements OnInit {
   }
 
   display(form) {
-    let strForm = JSON.stringify(form, null, '\t');
+    const strForm = JSON.stringify(form, null, '\t');
     this.ds.addDialog(
       SchemaModalComponent,
       { schema: strForm, title: 'Form' },

--- a/src/app/form-editor/snackbar/saved-snackbar.ts
+++ b/src/app/form-editor/snackbar/saved-snackbar.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'snackbar',
   template: `<div class="text-center">
     <span style="color:green"><i class="fa fa-check-circle fa-2x"></i></span>

--- a/src/app/form-editor/snackbar/snackbar.component.ts
+++ b/src/app/form-editor/snackbar/snackbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_SNACK_BAR_DATA } from '@angular/material';
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'snackbar',
   template: `<div class="text-center">
     <span style="color:green"><i class="fa fa-check-circle fa-2x"></i></span>

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -57,7 +57,7 @@
             />
           </div>
           <div
-            *ngIf="authenticated != undefined && !authenticated"
+            *ngIf="authenticated !==undefined && !authenticated"
             class="alert alert-danger"
           >
             <p>Incorrect username or password</p>
@@ -86,7 +86,7 @@
             [class.alert-success]="authenticated"
           >
             <small>{{ message }}</small>
-            <div *ngIf="message.indexOf('Logging') != -1" class="spinner">
+            <div *ngIf="message.indexOf('Logging') !==-1" class="spinner">
               <i class="fa fa-spinner fa-spin"></i>
             </div>
           </div>

--- a/src/app/modals/alert.component.ts
+++ b/src/app/modals/alert.component.ts
@@ -6,6 +6,7 @@ export interface AlertModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'alert',
   template: `<div class="modal-dialog">
     <div class="modal-content">

--- a/src/app/modals/answers-modal/answers.modal.ts
+++ b/src/app/modals/answers-modal/answers.modal.ts
@@ -12,6 +12,7 @@ export interface AnswersModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   templateUrl: './answers-modal.html',
   styleUrls: ['./answers-modal.css']
@@ -21,7 +22,7 @@ export class AnswersComponent
   implements AnswersModel, OnInit, AfterViewChecked {
   answers: any;
   checkboxes = [];
-  checked: boolean = false;
+  checked = false;
 
   constructor(
     dialogService: DialogService,

--- a/src/app/modals/concept.modal.ts
+++ b/src/app/modals/concept.modal.ts
@@ -14,6 +14,7 @@ export interface ConceptsModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   template: `<div class="modal-dialog">
     <div class="modal-content">

--- a/src/app/modals/confirm.component.ts
+++ b/src/app/modals/confirm.component.ts
@@ -51,7 +51,9 @@ export class ConfirmComponent
 
   close() {
     super.close();
-    if (!this.result) this.result = 0;
+    if (!this.result) {
+      this.result = 0;
+    }
   }
 
   confirm() {

--- a/src/app/modals/encounter-details.modal.ts
+++ b/src/app/modals/encounter-details.modal.ts
@@ -50,7 +50,9 @@ import * as _ from 'lodash';
   </div>`,
   providers: [PatientResourceService, LocationResourceService]
 })
-export class EncounterModalDetailsComponent extends DialogComponent<any, any> {
+export class EncounterModalDetailsComponent
+  extends DialogComponent<any, any>
+  implements OnInit {
   patients: any;
   form: any = { patient: '', location: '' };
   constructor(

--- a/src/app/modals/encounter-viewer-modal.ts
+++ b/src/app/modals/encounter-viewer-modal.ts
@@ -7,6 +7,7 @@ export interface EncounterViewerModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'encounter-viewer-modal',
   template: `<div class="modal-dialog modal-lg">
     <div class="modal-content">

--- a/src/app/modals/insert-reference-form-modal/insert-reference-forms.modal.ts
+++ b/src/app/modals/insert-reference-form-modal/insert-reference-forms.modal.ts
@@ -14,6 +14,7 @@ export interface ReferenceModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   templateUrl: './insert-reference-forms.modal.html',
   styleUrls: ['./insert-reference-forms.modal.css']
@@ -23,7 +24,7 @@ export class InsertReferenceComponent
   implements ReferenceModel, OnInit, AfterViewChecked {
   title: string;
   forms: any;
-  selected: boolean = false;
+  selected = false;
   errorMessage: string;
 
   constructor(
@@ -41,7 +42,7 @@ export class InsertReferenceComponent
   }
 
   save(value) {
-    let uuid = this.findFormUUID(value.refForm);
+    const uuid = this.findFormUUID(value.refForm);
 
     if (_.isUndefined(uuid)) {
       this.errorMessage = 'Invalid form.';
@@ -60,7 +61,9 @@ export class InsertReferenceComponent
   findFormUUID(formName) {
     let uuid;
     this.forms.forEach((form) => {
-      if (form.name == formName) uuid = form.uuid;
+      if (form.name === formName) {
+        uuid = form.uuid;
+      }
     });
     return uuid;
   }

--- a/src/app/modals/navigator.modal.ts
+++ b/src/app/modals/navigator.modal.ts
@@ -18,6 +18,7 @@ export interface NavigatorModalModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   template: `<div class="modal-dialog">
     <div class="modal-content">

--- a/src/app/modals/prompt.component.ts
+++ b/src/app/modals/prompt.component.ts
@@ -8,6 +8,7 @@ export interface PromptModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   template: `<div class="modal-dialog">
     <div class="modal-content">
@@ -72,7 +73,7 @@ export class PromptComponent
   implements PromptModel {
   title: string;
   questions: any;
-  message: string = '';
+  message = '';
   form: FormGroup;
 
   constructor(dialogService: DialogService) {
@@ -84,6 +85,8 @@ export class PromptComponent
   }
 
   keyDownFunction($event) {
-    if ($event.keyCode == 13 && this.form.valid) this.save();
+    if ($event.keyCode === 13 && this.form.valid) {
+      this.save();
+    }
   }
 }

--- a/src/app/modals/reference-form-modal/reference-form.modal.ts
+++ b/src/app/modals/reference-form-modal/reference-form.modal.ts
@@ -19,6 +19,7 @@ export interface ReferenceFormModalModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   templateUrl: './reference-form.modal.html',
   styleUrls: ['./reference-form.madal.css']
@@ -27,11 +28,11 @@ export class ReferenceModalComponent
   extends DialogComponent<ReferenceFormModalModel, string>
   implements ReferenceFormModalModel, OnInit, OnDestroy {
   title: string;
-  refElement: string; //new element to be refd
+  refElement: string; // new element to be refd
   form: FormGroup;
-  formAlias: string; //the form alias selected
+  formAlias: string; // the form alias selected
   refForms: any[];
-  searchValue: string = '';
+  searchValue = '';
   filteredForms: Observable<any[]>;
   selectField: FormControl = new FormControl('', Validators.required);
   errorMessage: string;
@@ -57,19 +58,19 @@ export class ReferenceModalComponent
 
   // filter(ref){
   //   return this.refForms.filter(form =>
-  //       form.formName.toLowerCase().indexOf(ref.toLowerCase()) != -1);
+  //       form.formName.toLowerCase().indexOf(ref.toLowerCase()) !==-1);
   // }
 
   save(value) {
     let selectedForm;
     this.refForms.forEach((form) => {
-      if (form['formName'] == value) {
+      if (form['formName'] === value) {
         selectedForm = form;
         this.formAlias = form['alias'];
       }
     });
 
-    if (selectedForm == undefined) {
+    if (selectedForm === undefined) {
       this.errorMessage = 'Please select a valid form';
       return;
     }
@@ -88,7 +89,9 @@ export class ReferenceModalComponent
               )
             )
         );
-    } else console.error('formName is undefined!');
+    } else {
+      console.error('formName is undefined!');
+    }
   }
 
   showNavigatorDialog(schema, refElement: string, title: string) {
@@ -103,11 +106,11 @@ export class ReferenceModalComponent
         { backdropColor: 'rgba(0, 0, 0, 0.8)' }
       )
       .subscribe((formValue) => {
-        let i = {};
+        const i = {};
         i['form'] = this.formAlias;
         i[refElement + 's'] = formValue;
 
-        if (formValue != undefined) {
+        if (formValue !== undefined) {
           console.log(i);
           this.result = JSON.stringify(i);
           this.close();
@@ -116,15 +119,16 @@ export class ReferenceModalComponent
   }
 
   keyDownFunction($event) {
-    //validate!
-    if ($event.keyCode == 13 && this.form.valid)
+    // validate!
+    if ($event.keyCode === 13 && this.form.valid) {
       this.save(this.selectField.value);
+    }
   }
 
   filterForms(searchString: string) {
     searchString = searchString.toLowerCase();
     return this.refForms.filter((form) => {
-      form.name.toLowerCase().indexOf(searchString) != -1;
+      return form.name.toLowerCase().indexOf(searchString) !== -1;
     });
   }
 

--- a/src/app/modals/save-form-modal/save-form-modal.html
+++ b/src/app/modals/save-form-modal/save-form-modal.html
@@ -21,14 +21,11 @@
           <input class="form-control" formControlName="version" />
         </div>
 
-        <div class="form-group" *ngIf="encounterTypes&&formType!='component'">
+        <div class="form-group" *ngIf="encounterTypes&&formType!==component'">
           <label for="encounter-type">Encounter Type</label>
           <select class="form-control" formControlName="encounter">
             <option value="" selected>Select Encounter Type</option>
-            <option
-              *ngFor="let e of encounterTypes"
-              [selected]="encounterType == e.display"
-            >
+            <option *ngFor="let e of encounterTypes" [selected]="encounterType === e.display">
               {{e.display}}
             </option>
           </select>
@@ -36,11 +33,7 @@
 
         <div class="form-group">
           <label>Description</label>
-          <textarea
-            class="form-control"
-            rows="4"
-            formControlName="description"
-          ></textarea>
+          <textarea class="form-control" rows="4" formControlName="description"></textarea>
         </div>
       </form>
     </div>

--- a/src/app/modals/save-form-modal/save-form-modal.ts
+++ b/src/app/modals/save-form-modal/save-form-modal.ts
@@ -91,16 +91,15 @@ export class SaveFormsComponent
           });
       }
       if (this.encounterType !== formValue.encounter) {
-        // tslint:disable-next-line:no-shadowed-variable
-        const encounterType = _.find(
+        const encType = _.find(
           this.encounterTypes,
           (encounterType: { display: any }) => {
             return encounterType.display === formValue.encounter;
           }
         );
-        if (encounterType) {
+        if (encType) {
           this.saveFormService
-            .updateEncounterType(encounterType, this.uuid)
+            .updateEncounterType(encType, this.uuid)
             .subscribe((res) => {
               this.updateForm();
             });

--- a/src/app/modals/schema-editor.modal.ts
+++ b/src/app/modals/schema-editor.modal.ts
@@ -8,6 +8,7 @@ export interface SchemaEditorModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   template: `<div class="modal-dialog">
     <div class="modal-content">

--- a/src/app/modals/set-members-modal/set-members-modal.component.ts
+++ b/src/app/modals/set-members-modal/set-members-modal.component.ts
@@ -25,6 +25,7 @@ interface Answer {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'set-members-modal',
   templateUrl: './set-members-modal.component.html',
   styleUrls: ['./set-members-modal.component.css']
@@ -59,7 +60,7 @@ export class SetMembersModalComponent
 
   setQuestions(event, i) {
     if (event.target.checked) {
-      let question: Questions = {
+      const question: Questions = {
         label: this.setMembers[i].display,
         concept: this.setMembers[i].uuid,
         answers: []
@@ -67,7 +68,7 @@ export class SetMembersModalComponent
       this.questionsChecked.push(question);
     } else {
       this.questionsChecked.forEach((question, index) => {
-        if (question.concept == this.setMembers[i].uuid) {
+        if (question.concept === this.setMembers[i].uuid) {
           this.questionsChecked.splice(index, 1);
           return;
         }
@@ -76,9 +77,9 @@ export class SetMembersModalComponent
   }
 
   setAnswers(event, i, j) {
-    let $ans = this.setMembers[i].answers[j];
+    const $ans = this.setMembers[i].answers[j];
     if (event.target.checked) {
-      let answer: Answer = {
+      const answer: Answer = {
         label: $ans.display,
         concept: $ans.uuid,
         conceptMappings: this.cs.createMappingsValue($ans.mappings)
@@ -86,8 +87,8 @@ export class SetMembersModalComponent
 
       this.questionsChecked.forEach((question, index) => {
         if (
-          question.concept == this.setMembers[i].uuid &&
-          question.answers.indexOf(answer) == -1
+          question.concept === this.setMembers[i].uuid &&
+          question.answers.indexOf(answer) === -1
         ) {
           this.questionsChecked[index]['answers'].push(answer);
           return;
@@ -96,7 +97,7 @@ export class SetMembersModalComponent
     } else {
       this.questionsChecked.forEach((question, qIndex) => {
         question.answers.forEach((answer, aIndex) => {
-          if (answer.concept == this.setMembers[i].answers[j].uuid) {
+          if (answer.concept === this.setMembers[i].answers[j].uuid) {
             this.questionsChecked[qIndex].answers.splice(aIndex, 1);
             return;
           }
@@ -106,9 +107,9 @@ export class SetMembersModalComponent
   }
 
   isQuestionChecked(index) {
-    let isChecked: boolean = false;
+    let isChecked = false;
     this.questionsChecked.forEach((question) => {
-      if (this.setMembers[index].display == question.label) {
+      if (this.setMembers[index].display === question.label) {
         isChecked = true;
       }
     });

--- a/src/app/modals/update-forms-wizard-modal/update-forms-wizard-modal.component.ts
+++ b/src/app/modals/update-forms-wizard-modal/update-forms-wizard-modal.component.ts
@@ -15,6 +15,7 @@ export interface UpdateFormsWizardModel {
 }
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'prompt',
   templateUrl: './update-forms-wizard-modal.component.html',
   styleUrls: ['./update-forms-wizard-modal.component.css']

--- a/src/app/pipes/string_to_number.pipe.ts
+++ b/src/app/pipes/string_to_number.pipe.ts
@@ -3,9 +3,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({ name: 'str2num' })
 export class Str2Num implements PipeTransform {
   transform(input: string): number {
-    //string type
-    let num = parseFloat(input);
-    if (num === 0.01) return parseFloat('1.0');
-    else return num + 0.1;
+    const num = parseFloat(input);
+    if (num === 0.01) {
+      return parseFloat('1.0');
+    } else {
+      return num + 0.1;
+    }
   }
 }

--- a/src/app/view-forms/view-forms.component.html
+++ b/src/app/view-forms/view-forms.component.html
@@ -1,15 +1,7 @@
 <mat-toolbar color="primary">
-  <span
-    class="menu"
-    style="font-size: 18px; font-family: 'Roboto'; color: white"
-    >Form Builder</span
-  >
+  <span class="menu" style="font-size: 18px; font-family: 'Roboto'; color: white">Form Builder</span>
   <span style="margin-left: 15px">
-    <button
-      mat-button
-      (click)="createNew()"
-      style="color: white; font-size: 14px"
-    >
+    <button mat-button (click)="createNew()" style="color: white; font-size: 14px">
       <i class="fa fa-plus-circle"></i> Create New
     </button>
   </span>
@@ -18,23 +10,13 @@
     </span> -->
   <span class="fill"></span>
   <span class="dropdown">
-    <button
-      class="btn btn-info dropdown-toggle"
-      type="button"
-      data-toggle="dropdown"
-    >
+    <button class="btn btn-info dropdown-toggle" type="button" data-toggle="dropdown">
       <i class="fa fa-user"></i> {{ username }} <span class="caret"></span>
     </button>
     <ul class="dropdown-menu pull-right">
       <li>
-        <a (click)="logout()"
-          ><i class="fa fa-sign-out" style="color: red"></i> Sign Out
-          <i
-            [class.fa-spinner]="loggingOut"
-            [class.fa-spin]="loggingOut"
-            class="fa"
-          ></i
-        ></a>
+        <a (click)="logout()"><i class="fa fa-sign-out" style="color: red"></i> Sign Out
+          <i [class.fa-spinner]="loggingOut" [class.fa-spin]="loggingOut" class="fa"></i></a>
       </li>
     </ul>
   </span>
@@ -68,10 +50,7 @@
         <div class="panel-heading">
           <div class="row">
             <div class="col col-xs-2">
-              <select
-                class="form-control panel-title"
-                (change)="onChange($event.target.value)"
-              >
+              <select class="form-control panel-title" (change)="onChange($event.target.value)">
                 <option>POC Forms</option>
                 <option>Component Forms</option>
               </select>
@@ -80,38 +59,19 @@
             <div class="col col-xs-5 pull-right">
               <div class="input-group">
                 <!-- Input -->
-                <input
-                  type="text"
-                  class="form-control"
-                  [(ngModel)]="searchValue"
-                  placeholder="Search"
-                  id="search-box"
-                />
-                <span
-                  class="input-group-addon"
-                  style="background: white; border-left: none"
-                >
+                <input type="text" class="form-control" [(ngModel)]="searchValue" placeholder="Search"
+                  id="search-box" />
+                <span class="input-group-addon" style="background: white; border-left: none">
                   <i class="fa fa-search"></i>
                 </span>
                 <!-- Dropdown -->
                 <div class="input-group-btn">
-                  <button
-                    type="button"
-                    class="btn btn-default"
-                    data-toggle="dropdown"
-                  >
-                    <i class="fa fa-filter"></i> Filter<span
-                      class="caret"
-                    ></span>
+                  <button type="button" class="btn btn-default" data-toggle="dropdown">
+                    <i class="fa fa-filter"></i> Filter<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu pull-right" role="menu">
                     <li>
-                      <input
-                        type="radio"
-                        name="filter"
-                        value="published"
-                        [(ngModel)]="searchFilter"
-                      />
+                      <input type="radio" name="filter" value="published" [(ngModel)]="searchFilter" />
                       Published
                     </li>
                   </ul>
@@ -132,77 +92,50 @@
               </tr>
             </thead>
             <tbody *ngIf="forms.length > 0">
-              <tr
-                *ngFor="
+              <tr *ngFor="
                   let form of forms
                     | formfilter: searchValue:searchFilter
                     | paginate: { itemsPerPage: 11, currentPage: page };
                   let i = index
-                "
-              >
+                ">
                 <td class="formName">
                   <b>{{ form.name }}</b>
                 </td>
                 <td>{{ form.version }}</td>
                 <td>
-                  <label *ngIf="form.published" class="label label-success"
-                    >Yes</label
-                  >
-                  <label *ngIf="!form.published" class="label label-danger"
-                    >No</label
-                  >
+                  <label *ngIf="form.published" class="label label-success">Yes</label>
+                  <label *ngIf="!form.published" class="label label-danger">No</label>
                 </td>
                 <td>
-                  <label *ngIf="form.retired" class="label label-danger"
-                    >Yes</label
-                  >
-                  <label *ngIf="!form.retired" class="label label-success"
-                    >No</label
-                  >
+                  <label *ngIf="form.retired" class="label label-danger">Yes</label>
+                  <label *ngIf="!form.retired" class="label label-success">No</label>
                 </td>
-                <td
-                  *ngIf="
-                    form.resources.length == 0 ||
+                <td *ngIf="
+                    form.resources.length === 0 ||
                     !form.resources[0]?.valueReference
-                  "
-                >
+                  ">
                   <a style="cursor: pointer">
-                    <i
-                      class="material-icons"
-                      (click)="addSchema(form)"
-                      data-toggle="tooltip"
-                      title="No schema associated with this form. Import schema?"
-                      >note_add</i
-                    >
+                    <i class="material-icons" (click)="addSchema(form)" data-toggle="tooltip"
+                      title="No schema associated with this form. Import schema?">note_add</i>
                   </a>
                 </td>
-                <td
-                  *ngIf="
+                <td *ngIf="
                     form.resources.length > 0 ||
                     form.resources[0]?.valueReference
-                  "
-                >
-                  <a
-                    (click)="editForm(form, form.uuid)"
-                    style="cursor: pointer"
-                    data-toggle="tooltip"
-                    title="Edit Schema"
-                  >
+                  ">
+                  <a (click)="editForm(form, form.uuid)" style="cursor: pointer" data-toggle="tooltip"
+                    title="Edit Schema">
                     <i class="material-icons edit">mode_edit</i>
                   </a>
-                  <a
-                    (click)="download(form.resources[0].valueReference)"
-                    style="cursor: pointer"
-                    data-toggle="tooltip"
-                    title="Download Schema"
-                  >
+                  <a (click)="download(form.resources[0].valueReference)" style="cursor: pointer" data-toggle="tooltip"
+                    title="Download Schema">
                     <i class="material-icons download">get_app</i>
                   </a>
                 </td>
               </tr>
             </tbody>
 
-            <tbody *ngIf="forms.length == 0">
+            <tbody *ngIf="forms.length === 0">
               <td>{{ loadingMessage }}</td>
               <td>-</td>
               <td>-</td>
@@ -212,9 +145,7 @@
         </div>
         <div class="panel-footer">
           <div class="row">
-            <pagination-controls
-              (pageChange)="page = $event"
-            ></pagination-controls>
+            <pagination-controls (pageChange)="page = $event"></pagination-controls>
           </div>
         </div>
       </div>

--- a/src/app/view-forms/view-forms.component.ts
+++ b/src/app/view-forms/view-forms.component.ts
@@ -96,10 +96,10 @@ export class ViewFormsComponent implements OnInit {
       this.restoreMessage = `Form ${
         this.ls.getObject(Constants.FORM_METADATA).name
       } was last worked on at ${new Date(
-        parseInt(timestamp)
+        parseInt(timestamp, 10)
       ).toLocaleDateString()}
     ${new Date(
-      parseInt(timestamp)
+      parseInt(timestamp, 10)
     ).toLocaleTimeString()} Would you like to continue working on this?`;
     }
   }

--- a/tslint.json
+++ b/tslint.json
@@ -45,7 +45,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [
@@ -70,7 +69,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [
@@ -91,9 +89,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
This PR:

- Bumps `tslint` from `v5.11.0` to `v5.20.1` (a [non-breaking](https://github.com/palantir/tslint/blob/master/CHANGELOG.md) change).
- Removes deprecated and unused `tslint` rules from our tslint config.
- Fixes a whole host of lint errors flagged by `tslint` resulting from:

  - missing whitespace
  - shadowed variable names
  - usage of `var` instead of `let`/`const` 
  - missing radix params in calls to `parseInt`
  - use of `==`/`!==` instead of strict equality/inequality
  - missing parentheses around `if` statements 