### PR TITLE
(feat) Tweak schema editor font and indentation

### DIFF
--- a/src/app/form-editor/schema-editor/schema-editor.component.css
+++ b/src/app/form-editor/schema-editor/schema-editor.component.css
@@ -1,10 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
+
 a {
   cursor: pointer;
   margin: 5px;
 }
+
 a:hover {
   color: #01a9ff;
 }
+
 a > i.material-icons.yellow {
   color: #ffa500 !important;
 }

--- a/src/app/form-editor/schema-editor/schema-editor.component.ts
+++ b/src/app/form-editor/schema-editor/schema-editor.component.ts
@@ -125,7 +125,9 @@ export class SchemaEditorComponent implements OnInit, OnDestroy {
       .subscribe((refFormArray) => (this.referencedForms = refFormArray));
 
     this.editor.getEditor().setOptions({
-      printMargin: false
+      fontFamily: 'Roboto Mono',
+      printMargin: false,
+      tabSize: 2
     });
     this.editor.setTheme('chrome');
     this.editor.setMode('json');


### PR DESCRIPTION
This PR:

- Adjusts the indentation in the schema editor by tweaking the tab size down from 4 to 2.
- Changes the font family in the schema editor to [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono), an arguably more readable typeface.