### PR TITLE
Replace hard to click navigator icons with easy to use buttons

### DIFF
--- a/src/app/form-editor/navigator/navigator.component.css
+++ b/src/app/form-editor/navigator/navigator.component.css
@@ -5,6 +5,7 @@
   text-decoration: none;
   display: inline-block;
 }
+
 .element {
   font-size: 16px;
   font-weight: 600;
@@ -38,8 +39,10 @@ a {
 }
 
 .formName {
-  margin-bottom: 20px;
+  width: 100%;
+  margin-bottom: 3rem;
 }
+
 .display {
   display: none;
 }
@@ -53,14 +56,9 @@ label {
   margin-bottom: 15px;
   padding: 10px 10px 10px 10px;
 }
+
 .selectMode {
   display: inline-block;
-}
-
-.formName {
-  width: 100%;
-  margin: 10px 10px 5px 0px;
-  padding: 10px 0px 0px 5px;
 }
 
 .pages {

--- a/src/app/form-editor/navigator/navigator.component.css
+++ b/src/app/form-editor/navigator/navigator.component.css
@@ -16,6 +16,7 @@
 .element:hover {
   color: #008cba;
 }
+
 a {
   color: white;
   font-size: 14px;
@@ -33,6 +34,7 @@ a {
 .well {
   border: none;
   background: none;
+  margin: 0.5rem 0;
 }
 
 .formName {
@@ -94,13 +96,16 @@ label {
 .badge.sec > a {
   color: #008cba !important;
 }
+
 .material-icons {
   color: #008cba;
   font-size: 18px;
 }
+
 .yellow {
   color: green;
 }
+
 .question-area {
   display: flex;
   justify-content: space-between;

--- a/src/app/form-editor/navigator/navigator.component.css
+++ b/src/app/form-editor/navigator/navigator.component.css
@@ -101,3 +101,8 @@ label {
 .yellow {
   color: green;
 }
+.question-area {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/app/form-editor/navigator/navigator.component.html
+++ b/src/app/form-editor/navigator/navigator.component.html
@@ -93,23 +93,21 @@
           style="float: right"
           [hidden]="editPageMode"
         >
-          <a *ngIf="!IsPageReferenced(i) && editMode"
-            ><i
-              (click)="showEditForm(page, i)"
-              class="material-icons"
-              aria-hidden="true"
-              >edit</i
-            ></a
+          <button
+            (click)="showEditForm(page, i)"
+            mat-button
+            color="primary"
+            *ngIf="!IsPageReferenced(i) && editMode"
           >
-          <a
-            ><i
-              class="material-icons del"
-              aria-hidden="true"
-              style="color: #8b0000"
-              (click)="showDeleteDialog(page, 'page', i)"
-              >delete_forever</i
-            ></a
+            Edit
+          </button>
+          <button
+            (click)="showDeleteDialog(page, 'page', i)"
+            mat-button
+            color="warn"
           >
+            Delete
+          </button>
         </div>
 
         <div
@@ -198,14 +196,17 @@
           style="float: right"
           [hidden]="editPageMode || editSectionMode"
         >
-          <a *ngIf="!IsSectionReferenced(pageIndex, j)"
-            ><i
-              (click)="showEditForm(section, pageIndex, j)"
-              class="fa fa-pencil"
-              aria-hidden="true"
-            ></i
-          ></a>
-          <a
+          <button
+            (click)="showEditForm(section, pageIndex, j)"
+            *ngIf="!IsSectionReferenced(pageIndex, j)"
+            mat-stroked-button
+            color="primary"
+          >
+            Edit
+          </button>
+          <button
+            mat-stroked-button
+            color="primary"
             *ngIf="
               IsSectionReferenced(pageIndex, j) &&
               IsSectionOnlyReferenced(pageIndex, j)
@@ -213,31 +214,21 @@
             (click)="editReferenceSection(pageIndex, j)"
             data-toggle="tooltip"
             title="Edit Referenced Section"
-            ><i
-              class="fa fa-reply-all"
-              style="color: green"
-              aria-hidden="true"
-            ></i
-          ></a>
-          <a
+          >
+            Edit Referenced Section
+          </button>
+          <button
+            mat-stroked-button
+            color="warn"
             *ngIf="
               !IsPageReferenced(pageIndex) &&
               IsSectionOnlyReferenced(pageIndex, j)
             "
-            ><i
-              class="fa fa-trash-o"
-              aria-hidden="true"
-              style="color: #8b0000"
-              (click)="showDeleteDialog(section, 'section', pageIndex, j)"
-            ></i
-          ></a>
+            (click)="showDeleteDialog(section, 'section', pageIndex, j)"
+          >
+            Delete
+          </button>
         </div>
-
-        <!--Exclude Section-->
-        <!-- <div *ngIf="selectMode&&_refElement=='page'" style="float:right;">
-          <a ><i class="fa fa-times" aria-hidden="true"  data-toggle="tooltip" title="Exclude section" style="color:red" (click)="excludeSection(pageIndex,j)"></i></a>
-          </div> -->
-
         <div
           [id]="
             'section' +
@@ -272,16 +263,12 @@
       >
         <i class="fa fa-plus"></i> Create new question</a
       >
-      <!-- <span style="border-right:1px solid lightgray;"></span>
-      <a style="cursor:pointer" data-toggle="tooltip" title="Reference question" (click)="addReferenceQuestion(pageIndex,sectionIndex,questionIndex)" class="ref" ><i class="fa fa-reply-all"></i> Reference Question</a> -->
     </div>
 
-    <div *ngFor="let question of schema.questions; let k = index">
-      <!-- <div *ngIf="selectMode&&_refElement=='question'" class="selectMode">
-      <input type="checkbox" 
-      (change)="emitCheckedReferenceElement($event,{'page':_formSchema.pages[pageIndex].label,'section':_formSchema.pages[pageIndex].sections[sectionIndex].label,'question':question.id || question.questions})">
-    </div> -->
-
+    <div
+      class="question-area"
+      *ngFor="let question of schema.questions; let k = index"
+    >
       <a
         *ngIf="question.questions"
         [href]="
@@ -307,24 +294,21 @@
         *ngIf="selectMode && _refElement == 'section' && question.id"
         style="float: right"
       >
-        <a
-          ><i
-            class="fa fa-times"
-            aria-hidden="true"
-            data-toggle="tooltip"
-            title="Exclude question"
-            style="color: red"
-            (click)="
-              excludeQuestion(
-                pageIndex,
-                sectionIndex,
-                k,
-                questionIndex,
-                question.id
-              )
-            "
-          ></i
-        ></a>
+        <button
+          (click)="
+            excludeQuestion(
+              pageIndex,
+              sectionIndex,
+              k,
+              questionIndex,
+              question.id
+            )
+          "
+          mat-stroked-button
+          color="warn"
+        >
+          Exclude question
+        </button>
       </div>
 
       <!-- Edit Question -->
@@ -333,33 +317,34 @@
         style="float: right"
         [hidden]="editPageMode || editSectionMode"
       >
-        <a *ngIf="!IsSectionReferenced(pageIndex, sectionIndex)"
-          ><i
-            (click)="
-              editQuestion(question, pageIndex, sectionIndex, k, questionIndex)
-            "
-            class="fa fa-pencil"
-            aria-hidden="true"
-          ></i
-        ></a>
-        <a *ngIf="!IsSectionReferenced(pageIndex, sectionIndex)"
-          ><i
-            class="fa fa-trash-o"
-            aria-hidden="true"
-            style="color: #8b0000"
-            (click)="
-              showDeleteDialog(
-                question,
-                'question',
-                pageIndex,
-                sectionIndex,
-                k,
-                questionIndex
-              )
-            "
-          ></i
-        ></a>
-        <a
+        <button
+          (click)="
+            editQuestion(question, pageIndex, sectionIndex, k, questionIndex)
+          "
+          mat-stroked-button
+          color="primary"
+          *ngIf="!IsSectionReferenced(pageIndex, sectionIndex)"
+        >
+          Edit
+        </button>
+        <button
+          mat-stroked-button
+          color="warn"
+          (click)="
+            showDeleteDialog(
+              question,
+              'question',
+              pageIndex,
+              sectionIndex,
+              k,
+              questionIndex
+            )
+          "
+          *ngIf="!IsSectionReferenced(pageIndex, sectionIndex)"
+        >
+          Delete
+        </button>
+        <button
           *ngIf="
             !IsPageReferenced(pageIndex) &&
             IsSectionReferenced(pageIndex, sectionIndex) &&
@@ -367,22 +352,19 @@
             question.id?.indexOf('__') == -1 &&
             questionIndex == undefined
           "
-          ><i
-            class="fa fa-times"
-            aria-hidden="true"
-            data-toggle="tooltip"
-            title="Exclude question"
-            style="color: red"
-            (click)="
-              excludeQuestionFromReferencedSection(
-                pageIndex,
-                sectionIndex,
-                k,
-                question.id
-              )
-            "
-          ></i
-        ></a>
+          mat-button
+          color="warn"
+          (click)="
+            excludeQuestionFromReferencedSection(
+              pageIndex,
+              sectionIndex,
+              k,
+              question.id
+            )
+          "
+        >
+          Exclude question
+        </button>
         <span
           *ngIf="question.id?.indexOf('__') >= 0"
           data-toggle="tooltip"

--- a/src/app/form-editor/navigator/navigator.component.html
+++ b/src/app/form-editor/navigator/navigator.component.html
@@ -75,7 +75,7 @@
             '#page' + page.label.slice(0, 2) + _formSchema.name.slice(0, 2) + i
           "
           data-toggle="collapse"
-          ><i class="fa fa-chevron-down"></i
+          ><i style="margin-right: 0.5rem" class="fa fa-chevron-down"></i
         ></a>
 
         <label (click)="onClicked(page, i)" class="element"
@@ -94,8 +94,9 @@
           [hidden]="editPageMode"
         >
           <button
+            style="margin-right: 0.5rem"
             (click)="showEditForm(page, i)"
-            mat-button
+            mat-stroked-button
             color="primary"
             *ngIf="!IsPageReferenced(i) && editMode"
           >
@@ -103,7 +104,7 @@
           </button>
           <button
             (click)="showDeleteDialog(page, 'page', i)"
-            mat-button
+            mat-stroked-button
             color="warn"
           >
             Delete
@@ -173,7 +174,7 @@
             j
           "
           data-toggle="collapse"
-          ><i class="fa fa-chevron-down"> </i
+          ><i style="margin-right: 0.5rem" class="fa fa-chevron-down"> </i
         ></a>
 
         <label (click)="onClicked(section, pageIndex, j)" class="element"
@@ -197,6 +198,7 @@
           [hidden]="editPageMode || editSectionMode"
         >
           <button
+            style="margin-right: 0.5rem"
             (click)="showEditForm(section, pageIndex, j)"
             *ngIf="!IsSectionReferenced(pageIndex, j)"
             mat-stroked-button
@@ -261,7 +263,8 @@
         (click)="addQuestion(pageIndex, sectionIndex, questionIndex)"
         class="create"
       >
-        <i class="fa fa-plus"></i> Create new question</a
+        <i style="margin-right: 0.5rem" class="fa fa-plus"></i> Create new
+        question</a
       >
     </div>
 
@@ -280,7 +283,7 @@
           k
         "
         data-toggle="collapse"
-        ><i class="fa fa-toggle-down"> </i
+        ><i style="margin-right: 0.5rem" class="fa fa-toggle-down"> </i
       ></a>
       <p
         class="element"
@@ -318,6 +321,7 @@
         [hidden]="editPageMode || editSectionMode"
       >
         <button
+          style="margin-right: 0.5rem"
           (click)="
             editQuestion(question, pageIndex, sectionIndex, k, questionIndex)
           "

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,6 +5,6 @@
 
 export const environment = {
   production: false,
-  date: '1634631641257',
+  date: '1656417287254',
   version: '1.0'
 };


### PR DESCRIPTION
### What does this PR do

Enhance the usability of `navigator` icons to button for ease of use. check the images below

### Before
<img width="649" alt="Screenshot 2022-06-27 at 21 19 31" src="https://user-images.githubusercontent.com/28008754/176009489-f93ca5cb-054c-4403-9ba1-e7069b7fc2bd.png">


### After 

<img width="711" alt="Screenshot 2022-06-27 at 21 14 20" src="https://user-images.githubusercontent.com/28008754/176009465-8bfa483b-b273-4e1c-9dd5-04f8bb5b41b8.png">
