### PR TITLE
(feat) More visual enhancements

### DIFF
--- a/src/app/form-editor/form-editor/form-editor.component.css
+++ b/src/app/form-editor/form-editor/form-editor.component.css
@@ -105,6 +105,7 @@ a {
 .errorToolbar {
   background: darkcyan;
 }
+
 .menu {
   margin-left: 10px;
 }
@@ -136,6 +137,7 @@ a {
   font-weight: 600;
   color: white;
 }
+
 .btn-default.active,
 .btn-default:active,
 .open > .dropdown-toggle.btn-default {
@@ -163,4 +165,8 @@ a {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+
+.docs-link {
+  text-decoration: none;
 }

--- a/src/app/form-editor/form-editor/form-editor.component.html
+++ b/src/app/form-editor/form-editor/form-editor.component.html
@@ -39,7 +39,7 @@
             <li>
               <a class="menuItem" (click)="saveLocally()">
                 <i class="glyphicon glyphicon-save mr-2" aria-hidden="true"></i>
-                <span>Save to disk</span></a
+                <span>Save draft to browser</span></a
               >
             </li>
             <li>
@@ -163,10 +163,15 @@
             </li>
           </ul>
         </div>
-
         <div class="btn-group">
-          <button type="button" class="btn btn-default" (click)="exit()">
-            <span class="fb-menu-item"> Exit form builder</span>
+          <button type="button" class="btn btn-default">
+            <a
+              class="fb-menu-item docs-link"
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://ampath-forms.vercel.app"
+              >Docs</a
+            >
           </button>
         </div>
       </span>
@@ -197,6 +202,10 @@
         <i style="font-size: 16px; margin-left: 0.5rem" class="material-icons"
           >arrow_forward</i
         >
+      </button>
+      <span class="space"></span>
+      <button type="button" class="btn btn-danger" (click)="exit()">
+        Exit
       </button>
     </mat-toolbar>
     <div id="audit-info" class="container collapse audit-content">

--- a/src/app/form-editor/form-editor/form-editor.component.ts
+++ b/src/app/form-editor/form-editor/form-editor.component.ts
@@ -86,7 +86,7 @@ export class FormEditorComponent
     public dialogService: DialogService,
     private localStorageService: LocalStorageService,
     private cdRef: ChangeDetectorRef,
-    private fectAllFormsService: FetchAllFormsService,
+    private fetchAllFormsService: FetchAllFormsService,
     private formListService: FormListService,
     private saveFormService: SaveFormService,
     private encounterTypeService: EncounterTypeService,
@@ -121,7 +121,8 @@ export class FormEditorComponent
     this.viewMode = this.getViewMode(); // default view mode
     this.user = this.sessionStorageService.getObject('user').username;
     this.url = this.sessionStorageService.getItem('url');
-    this.fectAllFormsService.getFormType().subscribe((res) => {
+    this.fetchAllFormsService.getFormType().subscribe((res) => {
+      console.log('res: ', res);
       if (res !== '') {
         this.formType = res;
         this.localStorageService.setItem('formType', this.formType);
@@ -177,7 +178,6 @@ export class FormEditorComponent
         }
         this.formType = this.localStorageService.getItem('formType');
       } else {
-        console.log('Get form', uuid);
         this.formMetadata.uuid = uuid;
         this.fs
           .fetchFormMetadata(this.formMetadata.uuid, false)
@@ -424,11 +424,13 @@ export class FormEditorComponent
       data: message
     });
   }
+
   showNotificationMessage(message: string) {
     this.snackbar.open(message, '', {
       duration: 1200
     });
   }
+
   setFormEditor(schema, rawSchema, formMetadata?) {
     this.selectedSchema = schema;
     this.schema = schema;
@@ -458,13 +460,14 @@ export class FormEditorComponent
         message =
           'This form has been published. Would you want to overwrite the existing form?';
       } else if (!_.isEmpty(this.formMetadata.uuid)) {
-        message = 'Would you want to update the form or save as a new version?';
+        message =
+          'Do you want to update the existing form or save it as a new version?';
       }
       this.dialogService
         .addDialog(
           ConfirmComponent,
           {
-            title: 'Confirm Save',
+            title: 'Save Form',
             message: message,
             buttonText: 'Update current version'
           },
@@ -472,13 +475,13 @@ export class FormEditorComponent
             backdropColor: 'rgba(0,0, 0, 0.5)'
           }
         )
-        .subscribe((decision) => {
-          if (decision === 1) {
+        .subscribe((choice) => {
+          if (choice === 1) {
             // overwrite existing form
             this.showSaveDialog('overwrite');
           }
 
-          if (decision === 2) {
+          if (choice === 2) {
             // save as a new version
             this.showSaveDialog('new', '0');
           }
@@ -490,13 +493,15 @@ export class FormEditorComponent
   }
 
   showSaveDialog(operation: string, newVersion?: string) {
-    const dialogTitle =
-      this.formType === Constants.POC ? 'POC FORM' : 'Component';
+    console.log('formType in dialog: ', this.formType);
+    // const dialogTitle =
+    //   this.formType === Constants.POC ? 'POC FORM' : 'Component';
     this.dialogService
       .addDialog(
         SaveFormsComponent,
         {
-          title: `Save ${dialogTitle}`,
+          // title: `Save ${dialogTitle}`,
+          title: `Save`,
           operation: operation,
           name: this.formMetadata.name,
           uuid: this.formMetadata.uuid,
@@ -576,7 +581,7 @@ export class FormEditorComponent
   publish(form, index) {
     let forms = [];
     const sameFormsDifferentVersion = [];
-    this.subscription = this.fectAllFormsService
+    this.subscription = this.fetchAllFormsService
       .fetchAllPOCForms()
       .subscribe((POCForms: any) => {
         forms = _.cloneDeep(POCForms.results); // currently only poc forms version 1
@@ -606,7 +611,7 @@ export class FormEditorComponent
                         title: 'Confirm publish',
                         message:
                           'There is already a version of this form published.' +
-                          'Would you like to unpublish that version and publish this one?',
+                          'Would you like to unpublish that version and publish this one instead?',
                         buttonText: 'Publish'
                       },
                       {

--- a/src/app/modals/confirm.component.ts
+++ b/src/app/modals/confirm.component.ts
@@ -12,13 +12,12 @@ export interface ConfirmModel {
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" (click)="close()">&times;</button>
-
         <h4 class="modal-title">{{ title || 'Confirm' }}</h4>
       </div>
       <div class="modal-body">
         <h5>{{ message || 'Are you sure you want to delete?' }}</h5>
       </div>
-      <div class="modal-footer">
+      <div class="modal-footer actions">
         <button type="button" class="btn btn-danger" (click)="confirm()">
           {{ buttonText || 'Delete' }}
         </button>
@@ -32,11 +31,22 @@ export interface ConfirmModel {
           </button>
         </div>
         <button type="button" class="btn btn-default" (click)="close()">
-          {{ 'Cancel' || canceButtonText }}
+          {{ 'Cancel' }}
         </button>
       </div>
     </div>
-  </div>`
+  </div>`,
+  styles: [
+    `
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+      }
+      .actions button {
+        margin: 0rem 0.5rem;
+      }
+    `
+  ]
 })
 export class ConfirmComponent
   extends DialogComponent<ConfirmModel, number>

--- a/src/app/modals/save-form-modal/save-form-modal.css
+++ b/src/app/modals/save-form-modal/save-form-modal.css
@@ -1,0 +1,8 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.actions button {
+  margin: 0rem 0.5rem;
+}

--- a/src/app/modals/save-form-modal/save-form-modal.html
+++ b/src/app/modals/save-form-modal/save-form-modal.html
@@ -44,8 +44,12 @@
         </div>
       </form>
     </div>
-    <div class="modal-footer">
-      <button [disabled]="isSavingForm" class="btn btn-primary" (click)="save(form.value)">
+    <div class="modal-footer actions">
+      <button
+        [disabled]="isSavingForm"
+        class="btn btn-primary"
+        (click)="save(form.value)"
+      >
         {{isSavingForm ? 'Saving form ...' : 'Ok'}}
       </button>
       <button type="button" class="btn btn-default" (click)="close()">

--- a/src/app/modals/save-form-modal/save-form-modal.ts
+++ b/src/app/modals/save-form-modal/save-form-modal.ts
@@ -29,7 +29,8 @@ export interface SaveFormModel {
 @Component({
   // tslint:disable-next-line:component-selector
   selector: 'save-form',
-  templateUrl: './save-form-modal.html'
+  templateUrl: './save-form-modal.html',
+  styleUrls: ['./save-form-modal.css']
 })
 export class SaveFormsComponent
   extends DialogComponent<SaveFormModel, any>


### PR DESCRIPTION
This PR:

- Adds a link to the Docs in the Form Builder navbar.
- Changes the copy of the `Save to disk` button to read `Save draft to browser`.
- Adds spacing between buttons in modals.
- Moves the `Exit` button in the navbar to the far right end of the form builder and adds styling that makes it stand out.

<img width="1920" alt="Screenshot 2022-07-07 at 22 42 36" src="https://user-images.githubusercontent.com/8509731/177860559-d43ff4e4-d587-4254-b0ec-892236308c85.png">